### PR TITLE
Post student skills endpoint

### DIFF
--- a/JobMatchBackend/.config/dotnet-tools.json
+++ b/JobMatchBackend/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "1.2.6",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/JobMatchBackend/Controllers/StudentSkillsController.cs
+++ b/JobMatchBackend/Controllers/StudentSkillsController.cs
@@ -16,9 +16,9 @@ public class StudentSkillsController : ControllerBase
     }
 
     [HttpPost("{studentId}/skills")]
-    [ProducesResponseType(StatusCodes.Status201Created)] 
-    [ProducesResponseType(StatusCodes.Status400BadRequest)] 
-    [ProducesResponseType(StatusCodes.Status404NotFound)] 
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> AddSkill(Guid studentId, [FromBody] AddSkillRequest request)
     {
         // Validate 400 Bad Request

--- a/JobMatchBackend/Controllers/StudentSkillsController.cs
+++ b/JobMatchBackend/Controllers/StudentSkillsController.cs
@@ -1,0 +1,34 @@
+using JobMatchBackend.DTOs.Request;
+using JobMatchBackend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JobMatchBackend.Controllers;
+
+[ApiController]
+[Route("api/students")]
+public class StudentSkillsController : ControllerBase
+{
+    private readonly ISkillService _skillService;
+
+    public StudentSkillsController(ISkillService skillService)
+    {
+        _skillService = skillService;
+    }
+
+    [HttpPost("{studentId}/skills")]
+    public async Task<IActionResult> AddSkill(Guid studentId, [FromBody] AddSkillRequest request)
+    {
+        // Validate 400 Bad Request
+        if (string.IsNullOrWhiteSpace(request.SkillName))
+            return BadRequest(new { message = "Skill name is required" });
+
+        var skill = await _skillService.AddSkillToStudentAsync(studentId, request.SkillName);
+
+        // validate 404 Not Found
+        if (skill == null)
+            return NotFound(new { message = "Student not found" });
+
+        // return 201 Created
+        return Created("", new { id = skill.Id, name = skill.Name });
+    }
+}

--- a/JobMatchBackend/Controllers/StudentSkillsController.cs
+++ b/JobMatchBackend/Controllers/StudentSkillsController.cs
@@ -16,6 +16,9 @@ public class StudentSkillsController : ControllerBase
     }
 
     [HttpPost("{studentId}/skills")]
+    [ProducesResponseType(StatusCodes.Status201Created)] 
+    [ProducesResponseType(StatusCodes.Status400BadRequest)] 
+    [ProducesResponseType(StatusCodes.Status404NotFound)] 
     public async Task<IActionResult> AddSkill(Guid studentId, [FromBody] AddSkillRequest request)
     {
         // Validate 400 Bad Request

--- a/JobMatchBackend/DTOs/Request/AddSkillRequest.cs
+++ b/JobMatchBackend/DTOs/Request/AddSkillRequest.cs
@@ -1,0 +1,3 @@
+namespace JobMatchBackend.DTOs.Request;
+
+public record AddSkillRequest(string SkillName);

--- a/JobMatchBackend/Data/AppDbContext.cs
+++ b/JobMatchBackend/Data/AppDbContext.cs
@@ -10,5 +10,20 @@ public class AppDbContext : DbContext
     }
 
     public DbSet<User> User => Set<User>();
-    
+    public DbSet<Skill> Skills { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Configure Many-to-Many relationship between User and Skill
+        modelBuilder.Entity<User>()
+            .HasMany(u => u.Skills)
+            .WithMany(s => s.Students)
+            .UsingEntity<Dictionary<string, object>>(
+                "student_skills",
+                j => j.HasOne<Skill>().WithMany().HasForeignKey("id_skill"),
+                j => j.HasOne<User>().WithMany().HasForeignKey("id_student")
+            );
+    }
 }

--- a/JobMatchBackend/Data/AppDbContext.cs
+++ b/JobMatchBackend/Data/AppDbContext.cs
@@ -11,6 +11,8 @@ public class AppDbContext : DbContext
 
     public DbSet<User> User => Set<User>();
     public DbSet<Skill> Skills { get; set; }
+    public DbSet<Job> Jobs => Set<Job>();
+    public DbSet<Application> Applications => Set<Application>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -25,5 +27,15 @@ public class AppDbContext : DbContext
                 j => j.HasOne<Skill>().WithMany().HasForeignKey("id_skill"),
                 j => j.HasOne<User>().WithMany().HasForeignKey("id_student")
             );
+
+        modelBuilder.Entity<Job>().HasKey(j => j.IdJob);
+        modelBuilder.Entity<Application>().HasKey(a => a.IdApplication);
+        
+        modelBuilder.Entity<Application>()
+            .HasIndex(a => new { a.IdJob, a.IdStudent })
+            .IsUnique()
+            .HasDatabaseName("IX_Application_Job_Student");
+
+        
     }
 }

--- a/JobMatchBackend/Migrations/20260421220450_AddStudentSkills.Designer.cs
+++ b/JobMatchBackend/Migrations/20260421220450_AddStudentSkills.Designer.cs
@@ -4,6 +4,7 @@ using JobMatchBackend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JobMatchBackend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421220450_AddStudentSkills")]
+    partial class AddStudentSkills
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JobMatchBackend/Migrations/20260421220450_AddStudentSkills.cs
+++ b/JobMatchBackend/Migrations/20260421220450_AddStudentSkills.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobMatchBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStudentSkills : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Skills",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Skills", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "student_skills",
+                columns: table => new
+                {
+                    id_skill = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    id_student = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_student_skills", x => new { x.id_skill, x.id_student });
+                    table.ForeignKey(
+                        name: "FK_student_skills_Skills_id_skill",
+                        column: x => x.id_skill,
+                        principalTable: "Skills",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_student_skills_User_id_student",
+                        column: x => x.id_student,
+                        principalTable: "User",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_student_skills_id_student",
+                table: "student_skills",
+                column: "id_student");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "student_skills");
+
+            migrationBuilder.DropTable(
+                name: "Skills");
+        }
+    }
+}

--- a/JobMatchBackend/Models/Entities/Skill.cs
+++ b/JobMatchBackend/Models/Entities/Skill.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JobMatchBackend.Models.Entities
+{
+    public class Skill
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Name { get; set; } = string.Empty;
+
+        //Many-to-Many relationship with Students (Users)
+        public ICollection<User> Students { get; set; } = new List<User>();
+    }
+}

--- a/JobMatchBackend/Models/Entities/User.cs
+++ b/JobMatchBackend/Models/Entities/User.cs
@@ -1,4 +1,6 @@
 namespace JobMatchBackend.Models.Entities;
+using System.Collections.Generic;
+using JobMatchBackend.Models.Entities;
 
 public class User
 {
@@ -22,5 +24,9 @@ public class User
     public string? CompanyId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
+
+    //for Many-to-Many relationship with Skills
+    public ICollection<Skill> Skills { get; set; } = new List<Skill>();
+
 }
 

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -3,6 +3,7 @@ using JobMatchBackend.Repositories;
 using JobMatchBackend.Services;
 using Microsoft.EntityFrameworkCore;
 
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<AppDbContext>(options =>
@@ -17,6 +18,9 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
+
+builder.Services.AddScoped<ISkillRepository, SkillRepository>();
+builder.Services.AddScoped<ISkillService, SkillService>();
 
 var app = builder.Build();
 

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -16,9 +16,11 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddScoped<IApplicationRepository, ApplicationRepository>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
 
+builder.Services.AddScoped<IApplicationService, ApplicationService>();
 builder.Services.AddScoped<ISkillRepository, SkillRepository>();
 builder.Services.AddScoped<ISkillService, SkillService>();
 

--- a/JobMatchBackend/Repositories/ISkillRepository.cs
+++ b/JobMatchBackend/Repositories/ISkillRepository.cs
@@ -1,0 +1,12 @@
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Repositories;
+
+public interface ISkillRepository
+{
+    Task<User?> GetStudentWithSkillsAsync(Guid studentId);
+    Task<Skill?> GetSkillByNameAsync(string name);
+    Task AddSkillAsync(Skill skill); // Nuevo
+    Task AddStudentSkillRelationAsync(Guid studentId, Guid skillId); // Nuevo
+    Task SaveChangesAsync();
+}

--- a/JobMatchBackend/Repositories/ISkillRepository.cs
+++ b/JobMatchBackend/Repositories/ISkillRepository.cs
@@ -6,7 +6,7 @@ public interface ISkillRepository
 {
     Task<User?> GetStudentWithSkillsAsync(Guid studentId);
     Task<Skill?> GetSkillByNameAsync(string name);
-    Task AddSkillAsync(Skill skill); // Nuevo
-    Task AddStudentSkillRelationAsync(Guid studentId, Guid skillId); // Nuevo
+    Task AddSkillAsync(Skill skill);
+    Task AddStudentSkillRelationAsync(Guid studentId, Guid skillId);
     Task SaveChangesAsync();
 }

--- a/JobMatchBackend/Repositories/SkillRepository.cs
+++ b/JobMatchBackend/Repositories/SkillRepository.cs
@@ -1,0 +1,51 @@
+using JobMatchBackend.Data;
+using JobMatchBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace JobMatchBackend.Repositories;
+
+public class SkillRepository : ISkillRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public SkillRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<User?> GetStudentWithSkillsAsync(Guid studentId)
+    {
+        return await _dbContext.User
+            .Include(u => u.Skills)
+            .FirstOrDefaultAsync(u => u.Id == studentId);
+    }
+
+    public async Task<Skill?> GetSkillByNameAsync(string name)
+    {
+        var normalized = name.Trim().ToLower();
+
+        return await _dbContext.Skills
+            .FirstOrDefaultAsync(s => s.Name.ToLower() == normalized);
+    }
+
+    public async Task AddSkillAsync(Skill skill)
+    {
+        await _dbContext.Skills.AddAsync(skill);
+    }
+
+    public async Task AddStudentSkillRelationAsync(Guid studentId, Guid skillId)
+    {
+        var relation = new Dictionary<string, object>
+        {
+            { "id_student", studentId },
+            { "id_skill", skillId }
+        };
+
+        await _dbContext.Set<Dictionary<string, object>>("student_skills").AddAsync(relation);
+    }
+
+    public async Task SaveChangesAsync()
+    {
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/JobMatchBackend/Services/ISkillService.cs
+++ b/JobMatchBackend/Services/ISkillService.cs
@@ -1,0 +1,8 @@
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Services;
+
+public interface ISkillService
+{
+    Task<Skill?> AddSkillToStudentAsync(Guid studentId, string skillName);
+}

--- a/JobMatchBackend/Services/SkillService.cs
+++ b/JobMatchBackend/Services/SkillService.cs
@@ -1,0 +1,35 @@
+using JobMatchBackend.Models.Entities;
+using JobMatchBackend.Repositories;
+
+namespace JobMatchBackend.Services;
+
+public class SkillService : ISkillService
+{
+    private readonly ISkillRepository _skillRepository;
+
+    public SkillService(ISkillRepository skillRepository)
+    {
+        _skillRepository = skillRepository;
+    }
+
+    public async Task<Skill?> AddSkillToStudentAsync(Guid studentId, string skillName)
+    {
+        var student = await _skillRepository.GetStudentWithSkillsAsync(studentId);
+        if (student == null) return null;
+
+        var skill = await _skillRepository.GetSkillByNameAsync(skillName);
+
+        if (skill == null)
+        {
+            skill = new Skill { Name = skillName };
+            await _skillRepository.AddSkillAsync(skill);
+        }
+        if (!student.Skills.Any(s => s.Name.ToLower() == skillName.ToLower()))
+        {
+            student.Skills.Add(skill);
+        }
+        await _skillRepository.SaveChangesAsync();
+
+        return skill;
+    }
+}

--- a/JobMatchBackend/appsettings.Development.json
+++ b/JobMatchBackend/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,1434;Database=JobMatch;User Id=sa;Password=Password123!;TrustServerCertificate=True"
   }
 }

--- a/JobMatchBackend/contracts/swagger.json
+++ b/JobMatchBackend/contracts/swagger.json
@@ -1,0 +1,188 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "JobMatchBackend",
+    "version": "1.0"
+  },
+  "paths": {
+    "/weatherforecast": {
+      "get": {
+        "tags": [
+          "JobMatchBackend"
+        ],
+        "operationId": "GetWeatherForecast",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WeatherForecast"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/Register": {
+      "post": {
+        "tags": [
+          "Register"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterStudent"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterStudent"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterStudent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/students/{studentId}/skills": {
+      "post": {
+        "tags": [
+          "StudentSkills"
+        ],
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSkillRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSkillRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSkillRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request - Skill name is required"
+          },
+          "404": {
+            "description": "Not Found - Student not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddSkillRequest": {
+        "type": "object",
+        "properties": {
+          "skillName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RegisterStudent": {
+        "required": [
+          "career",
+          "email",
+          "fullName",
+          "passwordHash",
+          "studentId",
+          "university"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "minLength": 1,
+            "type": "string",
+            "format": "email"
+          },
+          "passwordHash": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "fullName": {
+            "maxLength": 100,
+            "minLength": 5,
+            "type": "string"
+          },
+          "university": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "career": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "studentId": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WeatherForecast": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "temperatureC": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "temperatureF": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description:**
This pull request introduces the implementation of the Post Student Skills functionality, allowing skills to be associated with specific students.
The endpoint follows the defined API contract and adheres to the project’s layered architecture:
Controller → Service → Repository → Database

**_Changes Included:_** 

**Backend Implementation:**
- Implemented POST /api/students/{studentId}/skills endpoint.
- Added validation for input data (Skill Name is required).
- Implemented student existence validation (returns 404 if not found).
- Proper handling of HTTP responses:
      201 Created → Skill added successfully.
      400 Bad Request → Invalid input (empty skill name).
      404 Not Found → Student ID does not exist in the database.

**DTOs**
- Used AddSkillRequest for incoming data.
- The request body expects:
      skillName: String (Required).

**Service Layer**
- Integrated with ISkillService / SkillService.
- Handles:
      Verification of student existence.
      Creation of the skill record.
      Linking the skill to the student in the many-to-many relationship table.

**Controller**
- Updated StudentSkillsController.
- Decorated with [ProducesResponseType] for clear Swagger documentation (201, 400, 404).

**OpenAPI/Swagger**
- Updated contracts/swagger.json with the new endpoint definitions and error responses.

**API Behavior**
- Success: Returns 201 Created with the new skill ID and name.
- Errors:
        Returns 400 Bad Request when skillName is null or empty.
        Returns 404 Not Found when the studentId (GUID) does not match any record.

**Notes**
- The implementation ensures database integrity by validating foreign keys before insertion.
- The many-to-many relationship is correctly handled in the student_skills bridge table.

<img width="1774" height="912" alt="Screenshot 2026-04-28 111455" src="https://github.com/user-attachments/assets/ee2e3103-cefe-46d5-82cb-0eda05f78185" />

<img width="1790" height="889" alt="Screenshot 2026-04-28 111528" src="https://github.com/user-attachments/assets/0886fd77-1f82-4973-8732-266207580e1e" />

<img width="1815" height="867" alt="Screenshot 2026-04-28 111718" src="https://github.com/user-attachments/assets/27732d64-3468-4a08-b513-f470b13bdf3d" />
