### PR TITLE
Implementing getSkills

### DIFF
--- a/JobMatchBackend/Controllers/SkillsController.cs
+++ b/JobMatchBackend/Controllers/SkillsController.cs
@@ -1,0 +1,34 @@
+using JobMatchBackend.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JobMatchBackend.Controllers;
+
+[ApiController]
+[Route("skills")]
+[Authorize]
+public class SkillsController : ControllerBase
+{
+    private readonly ISkillService _skillService;
+
+    public SkillsController(ISkillService skillService)
+    {
+        _skillService = skillService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAllSkills()
+    {
+        try
+        {
+            var skills = await _skillService.GetAllSkillNamesAsync();
+            if (skills.Count == 0)
+                return NoContent();
+            return Ok(skills);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+}

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddScoped<IContractRepository, ContractRepository>();
 builder.Services.AddScoped<IJobRepository, JobRepository>();
 builder.Services.AddScoped<ICompanyRepository, CompanyRepository>();
 builder.Services.AddScoped<IStudentRepository, StudentRepository>();
+builder.Services.AddScoped<ISkillRepository, SkillRepository>();
 
 // Services
 builder.Services.AddScoped<IApplicationService, ApplicationService>();
@@ -54,6 +55,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IJobService, JobService>();
 builder.Services.AddScoped<ICompanyService, CompanyService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
+builder.Services.AddScoped<ISkillService, SkillService>();
 
 // Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/JobMatchBackend/Repositories/ISkillRepository.cs
+++ b/JobMatchBackend/Repositories/ISkillRepository.cs
@@ -1,0 +1,8 @@
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Repositories;
+
+public interface ISkillRepository
+{
+    Task<List<Skill>> GetAllAsync();
+}

--- a/JobMatchBackend/Repositories/SkillRepository.cs
+++ b/JobMatchBackend/Repositories/SkillRepository.cs
@@ -1,0 +1,20 @@
+using JobMatchBackend.Data;
+using JobMatchBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace JobMatchBackend.Repositories;
+
+public class SkillRepository : ISkillRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public SkillRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<List<Skill>> GetAllAsync()
+    {
+        return await _dbContext.Skills.ToListAsync();
+    }
+}

--- a/JobMatchBackend/Services/ISkillService.cs
+++ b/JobMatchBackend/Services/ISkillService.cs
@@ -1,0 +1,6 @@
+namespace JobMatchBackend.Services;
+
+public interface ISkillService
+{
+    Task<List<string>> GetAllSkillNamesAsync();
+}

--- a/JobMatchBackend/Services/SkillService.cs
+++ b/JobMatchBackend/Services/SkillService.cs
@@ -1,0 +1,19 @@
+using JobMatchBackend.Repositories;
+
+namespace JobMatchBackend.Services;
+
+public class SkillService : ISkillService
+{
+    private readonly ISkillRepository _skillRepository;
+
+    public SkillService(ISkillRepository skillRepository)
+    {
+        _skillRepository = skillRepository;
+    }
+
+    public async Task<List<string>> GetAllSkillNamesAsync()
+    {
+        var skills = await _skillRepository.GetAllAsync();
+        return skills.Select(s => s.Name).ToList();
+    }
+}


### PR DESCRIPTION
## Description
Implements the `GET /skills` endpoint that returns the full predefined skills catalogue. Students use this list to select skills when editing their profile.

---
## Related Issue
Closes #6

---
## Changes Included
### Backend Changes
* [x] Added new endpoint(s)
* [ ] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [x] Added exception handling
* [ ] Other:

---
## Architecture
Controller → Service → Repository → Database

`SkillsController` receives the request, delegates to `SkillService`, which calls `SkillRepository` to fetch all records from the `skills` table and returns them as a `string[]` of skill names.

---
## API / Database Changes
**New endpoint:**
`GET /skills`
- Returns `200 OK` with `string[]` of skill names
- Returns `204 No Content` if the table is empty
- Returns `500 Internal Server Error` on unexpected error
- Requires Bearer token

**No migrations added** — the `skills` table already existed from migration `AddSkillsAndAvailability`.

**New files:**
- `Repositories/ISkillRepository.cs`
- `Repositories/SkillRepository.cs`
- `Services/ISkillService.cs`
- `Services/SkillService.cs`
- `Controllers/SkillsController.cs`

**Modified:**
- `Program.cs` — registered `ISkillRepository/SkillRepository` and `ISkillService/SkillService`

---
## Testing Performed
* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [ ] Validation tested
* [ ] Backend integration tested
* [x] No crashes detected

### Test Details
Tested `GET /skills` via Swagger with a valid Bearer token. Returns 200 with the full list of 58 predefined skills in Spanish.

---
## Evidence
<img width="2080" height="1119" alt="image" src="https://github.com/user-attachments/assets/4a030435-b668-4e56-a4b2-6da7b6f0b1c2" />
<img width="2067" height="1046" alt="image" src="https://github.com/user-attachments/assets/a09cfabe-3a92-494c-826a-25e6dae714f9" />

---
## Notes
Skills were seeded directly into the database via SQL script. No seeder class was added to the project.