### PR TITLE
Implement removing skills from student profile #37

### DIFF
--- a/JobMatchBackend/Controllers/StudentsController.cs
+++ b/JobMatchBackend/Controllers/StudentsController.cs
@@ -90,4 +90,35 @@ public class StudentsController : ControllerBase
             return StatusCode(500, new { message = "Internal server error" });
         }
     }
+
+    [HttpDelete("{studentId}/skills/{skillId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RemoveSkillFromStudent(Guid studentId, Guid skillId)
+    {
+        try
+        {
+            await _studentService.GetStudentByIdAsync(studentId);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (callerId != studentId.ToString())
+            return Forbid();
+
+        try
+        {
+            await _studentService.RemoveSkillFromStudentAsync(studentId, skillId);
+            return NoContent();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+    }
 }

--- a/JobMatchBackend/Repositories/IStudentRepository.cs
+++ b/JobMatchBackend/Repositories/IStudentRepository.cs
@@ -7,6 +7,8 @@ public interface IStudentRepository
     Task<User?> GetByIdAsync(Guid studentId);
     Task<List<Skill>> GetSkillsByStudentIdAsync(Guid studentId);
     Task<Skill?> GetSkillByNameAsync(string skillName);
+    Task<Skill?> GetSkillByIdAsync(Guid skillId);
     Task<Skill> CreateSkillAsync(Skill skill);
     Task AddSkillAsync(Guid studentId, Guid skillId);
+    Task RemoveSkillAsync(Guid studentId, Guid skillId);
 }

--- a/JobMatchBackend/Repositories/StudentRepository.cs
+++ b/JobMatchBackend/Repositories/StudentRepository.cs
@@ -44,6 +44,12 @@ public class StudentRepository : IStudentRepository
         return skill;
     }
 
+    public async Task<Skill?> GetSkillByIdAsync(Guid skillId)
+    {
+        return await _dbContext.Skills
+            .FirstOrDefaultAsync(s => s.Id == skillId);
+    }
+
     public async Task AddSkillAsync(Guid studentId, Guid skillId)
     {
         _dbContext.StudentSkills.Add(new StudentSkill
@@ -53,5 +59,17 @@ public class StudentRepository : IStudentRepository
         });
 
         await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task RemoveSkillAsync(Guid studentId, Guid skillId)
+    {
+        var studentSkill = await _dbContext.StudentSkills
+            .FirstOrDefaultAsync(ss => ss.StudentId == studentId && ss.SkillId == skillId);
+
+        if (studentSkill != null)
+        {
+            _dbContext.StudentSkills.Remove(studentSkill);
+            await _dbContext.SaveChangesAsync();
+        }
     }
 }

--- a/JobMatchBackend/Services/IStudentService.cs
+++ b/JobMatchBackend/Services/IStudentService.cs
@@ -7,4 +7,5 @@ public interface IStudentService
     Task<StudentProfileResponse> GetStudentByIdAsync(Guid studentId);
     Task<List<string>> GetStudentSkillsAsync(Guid studentId);
     Task<string> AddSkillToStudentAsync(Guid studentId, string skillName);
+    Task RemoveSkillFromStudentAsync(Guid studentId, Guid skillId);
 }

--- a/JobMatchBackend/Services/StudentService.cs
+++ b/JobMatchBackend/Services/StudentService.cs
@@ -49,4 +49,17 @@ public class StudentService : IStudentService
         await _studentRepository.AddSkillAsync(studentId, skill.Id);
         return skill.Name;
     }
+
+    public async Task RemoveSkillFromStudentAsync(Guid studentId, Guid skillId)
+    {
+        var student = await _studentRepository.GetByIdAsync(studentId);
+        if (student == null)
+            throw new KeyNotFoundException("Student not found");
+
+        var hasSkill = student.StudentSkills.Any(ss => ss.SkillId == skillId);
+        if (!hasSkill)
+            throw new KeyNotFoundException("Skill not found for this student");
+
+        await _studentRepository.RemoveSkillAsync(studentId, skillId);
+    }
 }

--- a/JobMatchBackend/docs/Api contracts.yaml
+++ b/JobMatchBackend/docs/Api contracts.yaml
@@ -318,10 +318,14 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          description: Skill removed
-        "500":
-          description: Internal server error
+        "204":
+          description: Skill removed successfully
+        "401":
+          description: Unauthorized - missing or invalid token
+        "403":
+          description: Forbidden - caller does not match student ID
+        "404":
+          description: Student or skill not found
   /companies/{companyId}:
     get:
       tags:


### PR DESCRIPTION
# Pull Request

## Description

Implements the DELETE /students/{studentId}/skills/{skillId} endpoint, allowing an authenticated student to remove a skill from their own profile. The implementation follows the project's layered Clean Architecture and validates that the student exists, that the caller is authorized, and that the skill is actually linked to the student before removing it.

---

## Related Issue

Closes #37 

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [ ] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [x] Added validations
* [x] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture


HTTP Request
└── StudentsController
    ├── RemoveSkillFromStudent(studentId, skillId)
    ├── GetStudentByIdAsync() → 404 if student not found
    ├── GetCurrentUserId() (extracts caller id from JWT) → 403 if not owner
    └── IStudentService
        └── StudentService
            ├── RemoveSkillFromStudentAsync(studentId, skillId)
            ├── Student existence validation → 404
            ├── Student-skill ownership validation → 404
            ├── IStudentRepository
            │   ├── GetByIdAsync() — includes StudentSkills via EF eager loading
            │   ├── RemoveSkillAsync() — deletes from student_skills junction table only
            │   └── AppDbContext → SQL Server


---

## API / Database Changes
204 No Content | Skill successfully removed from student profile
401 Unauthorized | Missing or invalid JWT token
403 Forbidden | Authenticated user is not the owner of the student profile
404 Not Found | Student does not exist, or the skill is not linked to this student
---

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Tested via Swagger UI against local SQL Server:
Student removes their own skill | Valid student token + valid studentId + valid skillId | 204 No Content 
Student is not the profile owner | Valid token + different studentId | 403 Forbidden 
Student ID does not exist | Valid token + non-existing studentId | 404 Not Found
Skill not linked to student | Valid token + valid studentId + non-linked skillId | 404 Not Found
Unauthenticated request | No token | 401 Unauthorized 
Build validation | dotnet build | Build succeeds with 0 errors

---

## Evidence

<img width="1600" height="551" alt="image" src="https://github.com/user-attachments/assets/7e024954-ad52-428e-81d3-3b0fade893e6" />

<img width="1600" height="583" alt="image" src="https://github.com/user-attachments/assets/7db32095-8b80-4fe4-819e-0f491aed9280" />

<img width="1600" height="586" alt="image" src="https://github.com/user-attachments/assets/ee03fa48-e26f-4b08-9825-e9df97c61934" />

<img width="1600" height="735" alt="image" src="https://github.com/user-attachments/assets/30547346-3fdb-43a2-a3b0-4771190c271e" />

<img width="1600" height="754" alt="image" src="https://github.com/user-attachments/assets/becbe0e6-84a3-49a5-9c02-82ac37a64e7f" />

---
## Notes
The endpoint requires authentication via [Authorize] (inherited at controller class level).
Only the student whose JWT NameIdentifier matches studentId can remove a skill.
The student must have the skill linked in their profile; removing a skill that does not belong to the student returns 404.
Only the student_skills junction table row is deleted. The skill record in the skills table is not affected.
No database migration is required — no schema changes were made.
The 404 check for student existence is performed before the 403 ownership check to follow correct REST semantics.
