### PR TITLE
Implementation of active and completed contract filters

### DIFF
--- a/JobMatchBackend/Controllers/ContractsController.cs
+++ b/JobMatchBackend/Controllers/ContractsController.cs
@@ -1,0 +1,67 @@
+using JobMatchBackend.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace JobMatchBackend.Controllers;
+
+[ApiController]
+[Route("contracts")]
+[Authorize]
+public class ContractsController : ControllerBase
+{
+    private readonly IContractService _contractService;
+
+    public ContractsController(IContractService contractService)
+    {
+        _contractService = contractService;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetUserContracts([FromQuery] string? status)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var result = await _contractService.GetContractsByUserAsync(userId, status);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("{contractId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetContractById(int contractId)
+    {
+        try
+        {
+            var callerId = GetCurrentUserId();
+            var result = await _contractService.GetContractByIdAsync(contractId, callerId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(403, new { message = ex.Message });
+        }
+    }
+
+    private Guid GetCurrentUserId()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId) || !Guid.TryParse(userId, out var parsedUserId))
+            throw new UnauthorizedAccessException("Invalid authenticated user");
+        return parsedUserId;
+    }
+}

--- a/JobMatchBackend/DTOs/Response/ContractDetailResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ContractDetailResponse.cs
@@ -1,0 +1,22 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class ContractDetailResponse
+{
+    public int IdContract { get; set; }
+    public int IdJob { get; set; }
+    public string? JobTitle { get; set; }
+    public string? JobType { get; set; }
+    public DateOnly? StartDate { get; set; }
+    public DateOnly? EndDate { get; set; }
+    public decimal Payment { get; set; }
+    public string? PaymentType { get; set; }
+    public Guid IdStudent { get; set; }
+    public string? StudentName { get; set; }
+    public Guid IdCompany { get; set; }
+    public string? CompanyName { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string? ContractData { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? AcceptedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/JobMatchBackend/DTOs/Response/ContractSummaryResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ContractSummaryResponse.cs
@@ -1,0 +1,15 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class ContractSummaryResponse
+{
+    public int IdContract { get; set; }
+    public string? JobTitle { get; set; }
+    public string? CompanyName { get; set; }
+    public string? StudentName { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DateOnly? StartDate { get; set; }
+    public DateOnly? EndDate { get; set; }
+    public decimal Payment { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? AcceptedAt { get; set; }
+}

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<IJobService, JobService>();
 builder.Services.AddScoped<ICompanyService, CompanyService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddScoped<ISkillService, SkillService>();
+builder.Services.AddScoped<IContractService, ContractService>();
 
 // Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/JobMatchBackend/Repositories/ContractRepository.cs
+++ b/JobMatchBackend/Repositories/ContractRepository.cs
@@ -1,6 +1,6 @@
-// Repositories/ContractRepository.cs
 using JobMatchBackend.Data;
 using JobMatchBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace JobMatchBackend.Repositories;
 
@@ -18,5 +18,30 @@ public class ContractRepository : IContractRepository
         _dbContext.Contracts.Add(contract);
         await _dbContext.SaveChangesAsync();
         return contract;
+    }
+
+    public async Task<List<Contract>> GetByUserIdAsync(Guid userId, string? status)
+    {
+        var query = _dbContext.Contracts
+            .Include(c => c.Job)
+                .ThenInclude(j => j!.Company)
+            .Include(c => c.Student)
+            .Where(c => c.IdStudent == userId || c.IdCompany == userId);
+
+        if (!string.IsNullOrEmpty(status))
+            query = query.Where(c => c.Status == status);
+
+        return await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<Contract?> GetByIdAsync(int contractId)
+    {
+        return await _dbContext.Contracts
+            .Include(c => c.Job)
+                .ThenInclude(j => j!.Company)
+            .Include(c => c.Student)
+            .FirstOrDefaultAsync(c => c.IdContract == contractId);
     }
 }

--- a/JobMatchBackend/Repositories/IContractRepository.cs
+++ b/JobMatchBackend/Repositories/IContractRepository.cs
@@ -1,4 +1,3 @@
-// Repositories/IContractRepository.cs
 using JobMatchBackend.Models.Entities;
 
 namespace JobMatchBackend.Repositories;
@@ -6,4 +5,6 @@ namespace JobMatchBackend.Repositories;
 public interface IContractRepository
 {
     Task<Contract> CreateAsync(Contract contract);
+    Task<List<Contract>> GetByUserIdAsync(Guid userId, string? status);
+    Task<Contract?> GetByIdAsync(int contractId);
 }

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -1,0 +1,71 @@
+using JobMatchBackend.DTOs.Response;
+using JobMatchBackend.Repositories;
+
+namespace JobMatchBackend.Services;
+
+public class ContractService : IContractService
+{
+    private readonly IContractRepository _contractRepository;
+
+    public ContractService(IContractRepository contractRepository)
+    {
+        _contractRepository = contractRepository;
+    }
+
+    public async Task<List<ContractSummaryResponse>> GetContractsByUserAsync(Guid userId, string? status)
+    {
+        if (!string.IsNullOrEmpty(status) && status != "active" && status != "completed")
+            throw new ArgumentException("Status must be 'active' or 'completed'");
+
+        var contracts = await _contractRepository.GetByUserIdAsync(userId, status);
+
+        return contracts.Select(ToSummaryResponse).ToList();
+    }
+
+    public async Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid callerId)
+    {
+        var contract = await _contractRepository.GetByIdAsync(contractId);
+        if (contract == null)
+            throw new KeyNotFoundException("Contract not found");
+
+        if (contract.IdStudent != callerId && contract.IdCompany != callerId)
+            throw new UnauthorizedAccessException("You do not have access to this contract");
+
+        return ToDetailResponse(contract);
+    }
+
+    private static ContractSummaryResponse ToSummaryResponse(Models.Entities.Contract contract) => new()
+    {
+        IdContract = contract.IdContract,
+        JobTitle = contract.Job?.Title,
+        CompanyName = contract.Job?.Company?.CompanyName,
+        StudentName = contract.Student?.FullName,
+        Status = contract.Status ?? string.Empty,
+        StartDate = contract.Job?.StartDate,
+        EndDate = contract.Job?.EndDate,
+        Payment = contract.Job?.Payment ?? 0,
+        CreatedAt = contract.CreatedAt,
+        AcceptedAt = contract.AcceptedAt
+    };
+
+    private static ContractDetailResponse ToDetailResponse(Models.Entities.Contract contract) => new()
+    {
+        IdContract = contract.IdContract,
+        IdJob = contract.IdJob,
+        JobTitle = contract.Job?.Title,
+        JobType = contract.Job?.Type,
+        StartDate = contract.Job?.StartDate,
+        EndDate = contract.Job?.EndDate,
+        Payment = contract.Job?.Payment ?? 0,
+        PaymentType = contract.Job?.PaymentType,
+        IdStudent = contract.IdStudent,
+        StudentName = contract.Student?.FullName,
+        IdCompany = contract.IdCompany,
+        CompanyName = contract.Job?.Company?.CompanyName,
+        Status = contract.Status ?? string.Empty,
+        ContractData = contract.ContractData,
+        CreatedAt = contract.CreatedAt,
+        AcceptedAt = contract.AcceptedAt,
+        UpdatedAt = contract.UpdatedAt
+    };
+}

--- a/JobMatchBackend/Services/IContractService.cs
+++ b/JobMatchBackend/Services/IContractService.cs
@@ -1,0 +1,9 @@
+using JobMatchBackend.DTOs.Response;
+
+namespace JobMatchBackend.Services;
+
+public interface IContractService
+{
+    Task<List<ContractSummaryResponse>> GetContractsByUserAsync(Guid userId, string? status);
+    Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid callerId);
+}

--- a/JobMatchBackend/docs/Api contracts.yaml
+++ b/JobMatchBackend/docs/Api contracts.yaml
@@ -589,13 +589,8 @@ paths:
       tags:
         - Contracts
       summary: List contracts by user
-      description: Returns contracts filtered by status (active or completed).
+      description: Returns contracts for the authenticated user filtered by optional status (active or completed).
       parameters:
-        - name: userId
-          in: query
-          required: true
-          schema:
-            type: string
         - name: status
           in: query
           required: false
@@ -606,15 +601,15 @@ paths:
               - completed
       responses:
         "200":
-          description: List of contracts
+          description: List of contracts for the authenticated user
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/ContractSummary"
-        "500":
-          description: Internal server error
+        "400":
+          description: Invalid status value - must be 'active' or 'completed'
   /contracts/{contractId}:
     get:
       tags:
@@ -625,7 +620,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            type: integer
       responses:
         "200":
           description: Contract found
@@ -633,10 +628,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContractDetail"
+        "401":
+          description: Unauthorized - missing or invalid token
+        "403":
+          description: Forbidden - caller is not the student or company of this contract
         "404":
           description: Contract not found
-        "500":
-          description: Internal server error
   /contracts/{contractId}/accept:
     put:
       tags:


### PR DESCRIPTION

# Pull Request

## Description

Implements the GET /contracts and GET /contracts/{contractId} endpoints, allowing an authenticated user (student or company) to retrieve their own contracts. The list endpoint supports optional status filtering (active or completed). The detail endpoint validates that the caller is either the student or the company on the contract before returning the full data.

---

## Related Issue

Closes #18 

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [x] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [x] Added validations
* [x] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture

HTTP Request
└── ContractsController
    ├── GetUserContracts([FromQuery] status?)
    │   └── userId extracted from JWT → IContractService
    └── GetContractById(contractId)
        └── callerId extracted from JWT → IContractService
            └── ContractService
                ├── GetContractsByUserAsync(userId, status?)
                │   ├── Validates status value → ArgumentException if invalid
                │   └── IContractRepository.GetByUserIdAsync()
                │       WHERE IdStudent == userId OR IdCompany == userId
                │       + optional status filter + Include(Job→Company) + Include(Student)
                └── GetContractByIdAsync(contractId, callerId)
                    ├── Contract existence check → KeyNotFoundException
                    ├── Caller is student or company → UnauthorizedAccessException
                    └── IContractRepository.GetByIdAsync()
                        Include(Job→Company) + Include(Student)


---

## API / Database Changes

<html>
<body>
<!--StartFragment--><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">GET<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/contracts</code></h3>
Response | Description
-- | --
200 OK | List of contracts for the authenticated user. Empty array if none found
400 Bad Request | Status value is not active or completed

<!--EndFragment-->
</body>
</html><html>
<body>
<!--StartFragment--><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">GET<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/contracts</code></h3>
Response | Description
-- | --
200 OK | List of contracts for the authenticated user. Empty array if none found
400 Bad Request | Status value is not active or completed

<!--EndFragment-->
</body>
</html>
---

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected
---

## Evidence

<img width="1600" height="686" alt="image" src="https://github.com/user-attachments/assets/31048b08-c1da-47df-9689-916a7b2fd739" />

<img width="1600" height="686" alt="image" src="https://github.com/user-attachments/assets/f8b1ba6c-eb48-420a-ae72-cfcb5ae02b70" />

<img width="1600" height="685" alt="image" src="https://github.com/user-attachments/assets/8742ad4b-cbc4-4139-9579-e26e72d4e70b" />

<img width="1600" height="728" alt="image" src="https://github.com/user-attachments/assets/3450c55e-197a-444d-8506-f638a69a924f" />

<img width="1600" height="702" alt="image" src="https://github.com/user-attachments/assets/6749c32e-9a31-4997-8b3f-e68987ede337" />

<img width="1600" height="674" alt="image" src="https://github.com/user-attachments/assets/1ce6e768-059b-4ed6-931c-4747c89dd197" />






---

# Notes
Both endpoints require authentication via [Authorize] at class level — 401 is enforced automatically by the framework.
GET /contracts returns contracts where the authenticated user is either the student or the company — both roles use the same endpoint.
The status query parameter is optional. When omitted, all contracts for the user are returned regardless of status.
GET /contracts/{contractId} enforces access control: only the student or company on the contract can retrieve it.
No database migration required — no schema changes.
Include().ThenInclude() is used in both repository methods to avoid N+1 queries.
ContractService uses private static mapper methods (no separate mapper class), consistent with the existing contract module pattern in Develop.
Both endpoints belong to the same ticket and the same resource — included together in a single PR following the project convention.
