### PR TITLE
correct table names in application SQL query

### DIFF
--- a/JobMatchBackend/Repositories/ApplicationRepository.cs
+++ b/JobMatchBackend/Repositories/ApplicationRepository.cs
@@ -112,10 +112,10 @@ public class ApplicationRepository : IApplicationRepository
                         s.Email as StudentEmail,
                         s.University as StudentUniversity,
                         s.Career as StudentCareer
-                    FROM Applications a
-                    INNER JOIN Jobs j ON a.IdJob = j.IdJob
-                    INNER JOIN [User] u ON j.IdCompany = u.Id
-                    INNER JOIN [User] s ON a.IdStudent = s.Id
+                    FROM applications a
+                    INNER JOIN jobs j ON a.IdJob = j.IdJob
+                    INNER JOIN users u ON j.IdCompany = u.Id
+                    INNER JOIN users s ON a.IdStudent = s.Id
                     WHERE a.IdApplication = {applicationId}")
                 .FirstOrDefaultAsync();
             


### PR DESCRIPTION

# Pull Request

## Description

Correct the table names in the GetContractDataAsync raw SQL query
in ApplicationRepository.cs. They were using the old convention ([User], Applications, Jobs)
instead of the lowercase schema (users, applications, jobs) from the LowercaseSchema migration.

---

## Changes Included

### Backend Changes
* [x] Repositories/ApplicationRepository.cs: [User] → users, Applications → applications, Jobs → jobs