### PR TITLE
Allow companies to view student profiles

### DIFF
--- a/JobMatchBackend/Controllers/StudentsController.cs
+++ b/JobMatchBackend/Controllers/StudentsController.cs
@@ -22,10 +22,6 @@ public class StudentsController : ControllerBase
     [HttpGet("{studentId}")]
     public async Task<IActionResult> GetStudentById(Guid studentId)
     {
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (callerId != studentId.ToString())
-            return Forbid();
-
         try
         {
             var response = await _studentService.GetStudentByIdAsync(studentId);


### PR DESCRIPTION
## Description

Removes self-only restriction from GET /students/{studentId} so company users can view student profiles when reviewing applicants. Previously returned 403 Forbidden.

## Related Issue

Related to #32