### PR TITLE
Implementation of cancel job offer from the companie profile

### DIFF
--- a/JobMatchBackend/Controllers/JobsController.cs
+++ b/JobMatchBackend/Controllers/JobsController.cs
@@ -77,6 +77,38 @@ public class JobsController : ControllerBase
         }
     }
 
+    [Authorize]
+    [HttpDelete("{jobId}")]
+    public async Task<IActionResult> CancelJob(int jobId)
+    {
+        try
+        {
+            var companyId = GetCurrentUserId();
+            await _jobService.CancelJobAsync(jobId, companyId);
+            return Ok(new { message = "Job cancelled successfully" });
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { message = "Job not found" });
+        }
+        catch (UnauthorizedAccessException ex) when (ex.Message == "Invalid authenticated user")
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(403, new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreateJob([FromBody] CreateJobRequest request)
     {

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<ICompanyRepository, CompanyRepository>();
 builder.Services.AddScoped<IStudentRepository, StudentRepository>();
 builder.Services.AddScoped<ISkillRepository, SkillRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
+builder.Services.AddScoped<INotificationRepository, NotificationRepository>();
 
 // Services
 builder.Services.AddScoped<IApplicationService, ApplicationService>();

--- a/JobMatchBackend/Repositories/IJobRepository.cs
+++ b/JobMatchBackend/Repositories/IJobRepository.cs
@@ -12,4 +12,6 @@ public interface IJobRepository
     Task<Job> UpdateAsync(Job job);
     Task<bool> HasAcceptedApplicationsAsync(int jobId);
     Task<bool> HasActiveContractAsync(int jobId);
+    Task<Job> CancelAsync(Job job);
+    Task<List<Guid>> GetApplicantIdsByJobIdAsync(int jobId);
 }

--- a/JobMatchBackend/Repositories/INotificationRepository.cs
+++ b/JobMatchBackend/Repositories/INotificationRepository.cs
@@ -1,0 +1,8 @@
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Repositories;
+
+public interface INotificationRepository
+{
+    Task CreateManyAsync(List<Notification> notifications);
+}

--- a/JobMatchBackend/Repositories/JobRepository.cs
+++ b/JobMatchBackend/Repositories/JobRepository.cs
@@ -52,7 +52,7 @@ public class JobRepository : IJobRepository
     {
         return await _dbContext.Jobs
             .Include(j => j.Company)
-            .Where(j => j.Company != null && j.Company.IsActive)
+            .Where(j => j.Company != null && j.Company.IsActive && j.Status != "cancelled")
             .ToListAsync();
     }
 
@@ -73,5 +73,20 @@ public class JobRepository : IJobRepository
     {
         return await _dbContext.Contracts
             .AnyAsync(c => c.IdJob == jobId && c.Status == "active");
+    }
+
+    public async Task<Job> CancelAsync(Job job)
+    {
+        _dbContext.Jobs.Update(job);
+        await _dbContext.SaveChangesAsync();
+        return job;
+    }
+
+    public async Task<List<Guid>> GetApplicantIdsByJobIdAsync(int jobId)
+    {
+        return await _dbContext.Applications
+            .Where(a => a.IdJob == jobId && a.Status != "rejected")
+            .Select(a => a.IdStudent)
+            .ToListAsync();
     }
 }

--- a/JobMatchBackend/Repositories/NotificationRepository.cs
+++ b/JobMatchBackend/Repositories/NotificationRepository.cs
@@ -1,0 +1,20 @@
+using JobMatchBackend.Data;
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Repositories;
+
+public class NotificationRepository : INotificationRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public NotificationRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task CreateManyAsync(List<Notification> notifications)
+    {
+        _dbContext.Notifications.AddRange(notifications);
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/JobMatchBackend/Services/IJobService.cs
+++ b/JobMatchBackend/Services/IJobService.cs
@@ -9,4 +9,5 @@ public interface IJobService
     Task<List<JobResponse>> GetAllJobsAsync();
     Task<JobDetailResponse> GetJobByIdAsync(int jobId);
     Task<JobDetailResponse> UpdateJobAsync(int jobId, Guid companyId, UpdateJobRequest request);
+    Task CancelJobAsync(int jobId, Guid companyId);
 }

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -1,6 +1,7 @@
 using JobMatchBackend.DTOs.Request;
 using JobMatchBackend.DTOs.Response;
 using JobMatchBackend.Mappers;
+using JobMatchBackend.Models.Entities;
 using JobMatchBackend.Repositories;
 
 namespace JobMatchBackend.Services;
@@ -8,10 +9,12 @@ namespace JobMatchBackend.Services;
 public class JobService : IJobService
 {
     private readonly IJobRepository _jobRepository;
+    private readonly INotificationRepository _notificationRepository;
 
-    public JobService(IJobRepository jobRepository)
+    public JobService(IJobRepository jobRepository, INotificationRepository notificationRepository)
     {
         _jobRepository = jobRepository;
+        _notificationRepository = notificationRepository;
     }
 
     public async Task<JobResponse> CreateJobAsync(CreateJobRequest request)
@@ -129,5 +132,42 @@ public class JobService : IJobService
                 AvatarUrl = updated.Company?.AvatarUrl
             }
         };
+    }
+
+    public async Task CancelJobAsync(int jobId, Guid companyId)
+    {
+        var job = await _jobRepository.GetByIdWithCompanyAsync(jobId);
+        if (job == null)
+            throw new KeyNotFoundException("Job not found");
+
+        if (job.IdCompany != companyId)
+            throw new UnauthorizedAccessException("Company does not own this job");
+
+        if (job.Status == "cancelled")
+            throw new InvalidOperationException("Job is already cancelled");
+
+        var hasActiveContract = await _jobRepository.HasActiveContractAsync(jobId);
+        if (hasActiveContract)
+            throw new InvalidOperationException("Cannot cancel a job with an active contract");
+
+        var applicantIds = await _jobRepository.GetApplicantIdsByJobIdAsync(jobId);
+
+        job.Status = "cancelled";
+        job.UpdatedAt = DateTime.UtcNow;
+        await _jobRepository.CancelAsync(job);
+
+        if (applicantIds.Count > 0)
+        {
+            var notifications = applicantIds.Select(studentId => new Notification
+            {
+                IdUser = studentId,
+                Title = "Oferta cancelada",
+                Body = $"La oferta \"{job.Title}\" ha sido cancelada por la empresa.",
+                Type = "job_cancelled",
+                Data = $"{{\"jobId\": {jobId}}}"
+            }).ToList();
+
+            await _notificationRepository.CreateManyAsync(notifications);
+        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

Implements the DELETE /jobs/{jobId} endpoint so a company can cancel a job offer that is no longer needed. Cancelled offers are hidden from student searches immediately and all non-rejected applicants receive a simulated in-app notification.

---

## Related Issue

Closes #12 

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [ ] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [x] Added exception handling
* [x] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture

Client (Swagger / mobile app) → JobsController → IJobService (JobService) → IJobRepository (JobRepository) + INotificationRepository (NotificationRepository) → AppDbContext (EF Core) → Database
No new tables or migrations were required. The endpoint reuses the existing jobs, applications, and notifications tables. Job.Status was already present on the entity; setting it to "cancelled" is the chosen soft-cancel strategy, which preserves referential integrity given that applications and contracts both reference jobs with OnDelete: Restrict.

---

## API / Database Changes
New endpoint: DELETE /jobs/{jobId} — requires Bearer JWT (Company role)

Response 200 OK:


{ "message": "Job cancelled successfully" }
Response 400 Bad Request (job has an active contract):


{ "message": "Cannot cancel a job with an active contract" }
No database schema or migration changes were required. GetAllAsync in JobRepository was updated to filter out Status = "cancelled" jobs so they no longer appear in student-facing listings.

---

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [ ] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Tested manually via Swagger UI against the local Docker SQL Server database:

---

## Evidence
<img width="1600" height="686" alt="image" src="https://github.com/user-attachments/assets/29f666b0-3b55-40c2-b4b7-0f0081405c50" />

---

## Notes
Cancellation uses a soft-cancel approach (Status = "cancelled") rather than a hard delete to preserve the integrity of existing applications and contracts records linked to the job.
Applicant notifications are simulated: records are inserted into the notifications table (Type = "job_cancelled") for all applicants with status other than "rejected". No FCM push is triggered.
All other business guards (ownership check, double-cancel check) are enforced at the service layer even though the frontend cannot realistically trigger them, to protect direct API consumers.
