### PR TITLE
Implement GET /contracts endpoint for company contract listing

### DIFF
--- a/JobMatchBackend/Controllers/ContractsController.cs
+++ b/JobMatchBackend/Controllers/ContractsController.cs
@@ -7,7 +7,7 @@ namespace JobMatchBackend.Controllers;
 
 [ApiController]
 [Route("")]
-[Authorize(Roles = "Student")]
+[Authorize]
 public class ContractsController : ControllerBase
 {
     private readonly IContractService _contractService;
@@ -17,7 +17,29 @@ public class ContractsController : ControllerBase
         _contractService = contractService;
     }
 
+    // GET: /contracts?status=active
+    [Authorize(Roles = "Company")]
+    [HttpGet("contracts")]
+    public async Task<IActionResult> GetContracts([FromQuery] string? status)
+    {
+        try
+        {
+            var companyId = GetCurrentUserId();
+            var contracts = await _contractService.GetContractsByCompanyAsync(companyId, status);
+            return Ok(contracts);
+        }
+        catch (UnauthorizedAccessException ex) when (ex.Message == "Invalid authenticated user")
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     // PUT: /contracts/{contractId}/accept
+    [Authorize(Roles = "Student")]
     [HttpPut("contracts/{contractId}/accept")]
     public async Task<IActionResult> AcceptContract(int contractId)
     {

--- a/JobMatchBackend/DTOs/Response/ContractListResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ContractListResponse.cs
@@ -1,0 +1,13 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class ContractListResponse
+{
+    public int IdContract { get; set; }
+    public int IdJob { get; set; }
+    public string JobTitle { get; set; } = string.Empty;
+    public Guid IdStudent { get; set; }
+    public string StudentName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? AcceptedAt { get; set; }
+}

--- a/JobMatchBackend/Repositories/ContractRepository.cs
+++ b/JobMatchBackend/Repositories/ContractRepository.cs
@@ -32,4 +32,19 @@ public class ContractRepository : IContractRepository
         _dbContext.Contracts.Update(contract);
         await _dbContext.SaveChangesAsync();
     }
+
+    public async Task<List<Contract>> GetByCompanyIdAsync(Guid companyId, string? status)
+    {
+        var query = _dbContext.Contracts
+            .Include(c => c.Job)
+            .Include(c => c.Student)
+            .Where(c => c.IdCompany == companyId);
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(c => c.Status == status);
+
+        return await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ToListAsync();
+    }
 }

--- a/JobMatchBackend/Repositories/IContractRepository.cs
+++ b/JobMatchBackend/Repositories/IContractRepository.cs
@@ -8,4 +8,5 @@ public interface IContractRepository
     Task<Contract> CreateAsync(Contract contract);
     Task<Contract?> GetContractWithDetailsAsync(int contractId);
     Task UpdateAsync(Contract contract);
+    Task<List<Contract>> GetByCompanyIdAsync(Guid companyId, string? status);
 }

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -43,6 +43,23 @@ public class ContractService : IContractService
         };
     }
 
+    public async Task<List<ContractListResponse>> GetContractsByCompanyAsync(Guid companyId, string? status)
+    {
+        var contracts = await _contractRepository.GetByCompanyIdAsync(companyId, status);
+
+        return contracts.Select(c => new ContractListResponse
+        {
+            IdContract = c.IdContract,
+            IdJob = c.IdJob,
+            JobTitle = c.Job?.Title ?? string.Empty,
+            IdStudent = c.IdStudent,
+            StudentName = c.Student?.FullName ?? string.Empty,
+            Status = c.Status ?? string.Empty,
+            CreatedAt = c.CreatedAt,
+            AcceptedAt = c.AcceptedAt
+        }).ToList();
+    }
+
     private static ContractResponse ToContractResponse(Models.Entities.Contract contract)
     {
         return new ContractResponse

--- a/JobMatchBackend/Services/IContractService.cs
+++ b/JobMatchBackend/Services/IContractService.cs
@@ -5,4 +5,5 @@ namespace JobMatchBackend.Services;
 public interface IContractService
 {
     Task<ContractAcceptResponse> AcceptContractAsync(int contractId, Guid studentId);
+    Task<List<ContractListResponse>> GetContractsByCompanyAsync(Guid companyId, string? status);
 }


### PR DESCRIPTION
# Pull Request

## Description

Implements the GET /contracts endpoint so a company can retrieve the list of contracts associated with their account, with optional filtering by status. The existing PUT /contracts/{contractId}/accept endpoint was not modified; only its role restriction was moved from the class level to the method level to allow the new Company-scoped endpoint to coexist in the same controller.

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [x] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [x] Added exception handling
* [ ] Other:

---

## Architecture

Client (Swagger / mobile app) → ContractsController → IContractService (ContractService) → IContractRepository (ContractRepository) → AppDbContext (EF Core) → Database

The companyId is extracted exclusively from the JWT claim — never from the request body — so a company can only retrieve contracts where they are the IdCompany. The status filter is applied as an EF Core parameterized Where clause, with no SQL injection risk

---

## API / Database Changes

New endpoint: GET /contracts — requires Bearer JWT (Company role)

Query parameter: status (optional) — filters by contract status (e.g. active, pending)

Response 200 OK:


[
  {
    "idContract": 1,
    "idJob": 3,
    "jobTitle": "Desarrollador Flutter",
    "idStudent": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "studentName": "Carlos Estudiante",
    "status": "active",
    "createdAt": "2026-06-17T20:00:00Z",
    "acceptedAt": "2026-06-17T20:05:00Z"
  }
]
Response 200 OK (no contracts or no match for status filter): []

No database schema or migration changes were required. The endpoint reuses the existing contracts, jobs, and users tables via EF Core navigation properties.

Controller restructure: [Authorize(Roles = "Student")] was moved from the class level to the AcceptContract method, and [Authorize(Roles = "Company")] was added to the new GetContracts method. The class retains [Authorize] to ensure all unauthenticated requests are rejected at the framework level before reaching any method.

---

## Testing Performed

* [x] Feature tested manually
* [x] Navigation tested
* [ ] Error handling tested
* [ ] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Full flow tested manually via Swagger UI:

Registered a company and a student, created a job as the company.
Applied to the job as the student via POST /applications.
Accepted the application as the company via PUT /applications/{id} → contract generated with status: "pending".
Accepted the contract as the student via PUT /contracts/{id}/accept → contract moved to status: "active".
Happy path: Called GET /contracts with the company token → returned 200 OK with the contract list including job title and student name.
Status filter: Called GET /contracts?status=active → returned only active contracts. Called GET /contracts?status=pending → returned [].
Empty list: Called GET /contracts with a company that has no contracts → returned 200 OK with [].

---

## Evidence

<img width="1600" height="731" alt="image" src="https://github.com/user-attachments/assets/8f2a1d75-36db-485c-92ad-6236514cba4a" />

---
