### PR TITLE
Implement GET /contracts/{contractId} endpoint

### DIFF
--- a/JobMatchBackend/Controllers/ContractsController.cs
+++ b/JobMatchBackend/Controllers/ContractsController.cs
@@ -7,7 +7,7 @@ namespace JobMatchBackend.Controllers;
 
 [ApiController]
 [Route("")]
-[Authorize(Roles = "Student")]
+[Authorize]
 public class ContractsController : ControllerBase
 {
     private readonly IContractService _contractService;
@@ -17,7 +17,37 @@ public class ContractsController : ControllerBase
         _contractService = contractService;
     }
 
+    // GET: /contracts/{contractId}
+    [HttpGet("contracts/{contractId}")]
+    public async Task<IActionResult> GetContractById(int contractId)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var userRole = GetCurrentUserRole();
+            var result = await _contractService.GetContractByIdAsync(contractId, userId, userRole);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { message = "Contract not found" });
+        }
+        catch (UnauthorizedAccessException ex) when (ex.Message == "Invalid authenticated user")
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(403, new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     // PUT: /contracts/{contractId}/accept
+    [Authorize(Roles = "Student")]
     [HttpPut("contracts/{contractId}/accept")]
     public async Task<IActionResult> AcceptContract(int contractId)
     {
@@ -30,6 +60,10 @@ public class ContractsController : ControllerBase
         catch (KeyNotFoundException)
         {
             return NotFound(new { message = "Contract not found" });
+        }
+        catch (UnauthorizedAccessException ex) when (ex.Message == "Invalid authenticated user")
+        {
+            return Unauthorized(new { message = ex.Message });
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -48,8 +82,13 @@ public class ContractsController : ControllerBase
     private Guid GetCurrentUserId()
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!Guid.TryParse(userId, out var parsedUserId))
+        if (string.IsNullOrWhiteSpace(userId) || !Guid.TryParse(userId, out var parsedUserId))
             throw new UnauthorizedAccessException("Invalid authenticated user");
         return parsedUserId;
+    }
+
+    private string GetCurrentUserRole()
+    {
+        return User.FindFirstValue(ClaimTypes.Role) ?? string.Empty;
     }
 }

--- a/JobMatchBackend/DTOs/Response/ContractDetailResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ContractDetailResponse.cs
@@ -1,0 +1,19 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class ContractDetailResponse
+{
+    public int IdContract { get; set; }
+    public int IdApplication { get; set; }
+    public int IdJob { get; set; }
+    public string JobTitle { get; set; } = string.Empty;
+    public Guid IdStudent { get; set; }
+    public string StudentName { get; set; } = string.Empty;
+    public string StudentEmail { get; set; } = string.Empty;
+    public Guid IdCompany { get; set; }
+    public string CompanyName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? ContractData { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? AcceptedAt { get; set; }
+}

--- a/JobMatchBackend/Repositories/ContractRepository.cs
+++ b/JobMatchBackend/Repositories/ContractRepository.cs
@@ -24,6 +24,9 @@ public class ContractRepository : IContractRepository
     {
         return await _dbContext.Contracts
             .Include(c => c.Job)
+                .ThenInclude(j => j!.Company)
+            .Include(c => c.Student)
+            .Include(c => c.Company)
             .FirstOrDefaultAsync(c => c.IdContract == contractId);
     }
 

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -43,6 +43,38 @@ public class ContractService : IContractService
         };
     }
 
+    public async Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid userId, string userRole)
+    {
+        var contract = await _contractRepository.GetContractWithDetailsAsync(contractId);
+        if (contract == null)
+            throw new KeyNotFoundException("Contract not found");
+
+        var hasAccess =
+            (userRole == "Student" && contract.IdStudent == userId) ||
+            (userRole == "Company" && contract.IdCompany == userId);
+
+        if (!hasAccess)
+            throw new UnauthorizedAccessException("You don't have permission to view this contract");
+
+        return new ContractDetailResponse
+        {
+            IdContract = contract.IdContract,
+            IdApplication = contract.IdApplication,
+            IdJob = contract.IdJob,
+            JobTitle = contract.Job?.Title ?? string.Empty,
+            IdStudent = contract.IdStudent,
+            StudentName = contract.Student?.FullName ?? string.Empty,
+            StudentEmail = contract.Student?.Email ?? string.Empty,
+            IdCompany = contract.IdCompany,
+            CompanyName = contract.Company?.CompanyName ?? string.Empty,
+            Status = contract.Status ?? string.Empty,
+            ContractData = contract.ContractData,
+            CreatedAt = contract.CreatedAt,
+            UpdatedAt = contract.UpdatedAt,
+            AcceptedAt = contract.AcceptedAt
+        };
+    }
+
     private static ContractResponse ToContractResponse(Models.Entities.Contract contract)
     {
         return new ContractResponse

--- a/JobMatchBackend/Services/IContractService.cs
+++ b/JobMatchBackend/Services/IContractService.cs
@@ -5,4 +5,5 @@ namespace JobMatchBackend.Services;
 public interface IContractService
 {
     Task<ContractAcceptResponse> AcceptContractAsync(int contractId, Guid studentId);
+    Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid userId, string userRole);
 }


### PR DESCRIPTION
# Pull Request

## Description

Adds GET /contracts/{contractId} to allow both Students and Companies to retrieve a specific contract's full detail.

Access rules:
A Student can only view a contract where contract.IdStudent == their userId
A Company can only view a contract where contract.IdCompany == their userId
Any other authenticated user gets 403

---

## Changes Included

DTOs/Response/ContractDetailResponse.cs (new)
Enriched response with JobTitle, StudentName, StudentEmail, and CompanyName — richer than the base ContractResponse used in other endpoints.

Repositories/ContractRepository.cs
Extended GetContractWithDetailsAsync to also .Include(c => c.Student), .Include(c => c.Company), and .ThenInclude(j => j.Company) on the Job — covers all navigation properties needed for the detail response.

Services/IContractService.cs
Added GetContractByIdAsync(int contractId, Guid userId, string userRole).

Services/ContractService.cs
Implemented dual-role ownership check (same pattern as ApplicationService.GetApplicationDetailsAsync). Throws UnauthorizedAccessException if neither role condition matches.

Controllers/ContractsController.cs

Moved class-level [Authorize(Roles = "Student")] to plain [Authorize] so both roles can reach the controller
Added [Authorize(Roles = "Student")] explicitly on AcceptContract to preserve its restriction
Added GET /contracts/{contractId} endpoint with GetCurrentUserRole() helper (matches pattern in ApplicationsController)

---

## Testing Performed

Login as Student → POST /auth/login
Apply to a job → POST /applications
Login as Company → accept application → PUT /applications/{id} with {"status": "accepted"} (generates contract)
Login back as Student → PUT /contracts/{contractId}/accept
GET GET /contracts/{contractId} with the Student token → 200 with full detail
Switch to Company token → same request → 200
Login as a different Student → same request → 403

---

## Evidence
<img width="1600" height="726" alt="image" src="https://github.com/user-attachments/assets/03c2ad03-f4cc-48e6-b948-784b039bcdf8" />

<img width="1600" height="744" alt="image" src="https://github.com/user-attachments/assets/34a1a5b5-b743-4bfd-bb1e-79a86b34437d" />

<img width="1600" height="650" alt="image" src="https://github.com/user-attachments/assets/bdd0e1b4-1d7c-424e-ac54-19c007b76960" />

---