### PR TITLE
fix applications dates

### DIFF
--- a/JobMatchBackend/Services/ApplicationService.cs
+++ b/JobMatchBackend/Services/ApplicationService.cs
@@ -126,12 +126,8 @@ public class ApplicationService : IApplicationService
             studentUniversity = data.StudentUniversity,
             studentCareer = data.StudentCareer,
             workType = data.JobType ?? "Not specified",
-            startDate = job.StartDate.HasValue
-                ? job.StartDate.Value.ToString("yyyy-MM-dd")
-                : DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd"),
-            endDate = job.EndDate.HasValue
-                ? job.EndDate.Value.ToString("yyyy-MM-dd")
-                : DateTime.UtcNow.AddMonths(3).ToString("yyyy-MM-dd"),
+            startDate = job.StartDate?.ToString("yyyy-MM-dd"),
+            endDate = job.EndDate?.ToString("yyyy-MM-dd"),
             compensation = "To be defined by agreement",
             clauses = new[]
             {

--- a/JobMatchBackend/Services/ApplicationService.cs
+++ b/JobMatchBackend/Services/ApplicationService.cs
@@ -126,8 +126,12 @@ public class ApplicationService : IApplicationService
             studentUniversity = data.StudentUniversity,
             studentCareer = data.StudentCareer,
             workType = data.JobType ?? "Not specified",
-            startDate = DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd"),
-            endDate = DateTime.UtcNow.AddMonths(3).ToString("yyyy-MM-dd"),
+            startDate = job.StartDate.HasValue
+                ? job.StartDate.Value.ToString("yyyy-MM-dd")
+                : DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd"),
+            endDate = job.EndDate.HasValue
+                ? job.EndDate.Value.ToString("yyyy-MM-dd")
+                : DateTime.UtcNow.AddMonths(3).ToString("yyyy-MM-dd"),
             compensation = "To be defined by agreement",
             clauses = new[]
             {


### PR DESCRIPTION
# Pull Request

## Description

Fix: use job dates in contract generation

GenerateContractAsync was ignoring job.StartDate and job.EndDate, generating every contract with the same hardcoded dates (today +7 days / +3 months). Contract dates now come directly from the job.

Changed: one line in ApplicationService.cs — GenerateContractAsync. No migrations, no entity changes.