### PR TITLE
Fix account delete

### DIFF
--- a/JobMatchBackend/Properties/launchSettings.json
+++ b/JobMatchBackend/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5293",
+      "applicationUrl": "http://0.0.0.0:5293",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/JobMatchBackend/Repositories/UserRepository.cs
+++ b/JobMatchBackend/Repositories/UserRepository.cs
@@ -29,7 +29,7 @@ public class UserRepository : IUserRepository
 
     public User? GetByEmail(string email)
     {
-        return _dbContext.User.FirstOrDefault(u => u.Email == email);
+        return _dbContext.User.FirstOrDefault(u => u.Email == email && u.IsActive);
     }
 
 

--- a/JobMatchBackend/Services/UserService.cs
+++ b/JobMatchBackend/Services/UserService.cs
@@ -23,7 +23,7 @@ public class UserService : IUserService
     public async Task<RegisterStudentResponse> CreateStudentAsync(RegisterStudent request)
     {
 
-        var existingUser = await _dbContext.User.FirstOrDefaultAsync(u => u.Email == request.Email);
+        var existingUser = await _dbContext.User.FirstOrDefaultAsync(u => u.Email == request.Email && u.IsActive);
 
         if (existingUser != null)
         {
@@ -45,14 +45,14 @@ public class UserService : IUserService
     public async Task<RegisterCompanyResponse> CreateCompanyAsync(RegisterCompany request)
     {
 
-        var existingUser = await _dbContext.User.FirstOrDefaultAsync(u => u.CompanyId == request.CompanyId);
+        var existingUser = await _dbContext.User.FirstOrDefaultAsync(u => u.CompanyId == request.CompanyId && u.IsActive);
 
         if (existingUser != null)
         {
             throw new InvalidOperationException("La cedula de identificacion de esta empresa ya se encuentra registrada.");
         }
 
-        var existingUserByEmail = await _dbContext.User.FirstOrDefaultAsync(u => u.Email == request.Email);
+        var existingUserByEmail = await _dbContext.User.FirstOrDefaultAsync(u => u.Email == request.Email && u.IsActive);
 
         if (existingUserByEmail != null)
         {


### PR DESCRIPTION
# Pull Request

## Description

Implements soft delete for user accounts via DELETE /users/{userId}. Requires password confirmation and verifies the authenticated user matches the target. Sets IsActive = false and DeletedAt on the record. Also fixes email/companyId uniqueness checks in registration and login to filter by IsActive, so a deleted account's credentials can be reused after deletion.