### PR TITLE
Implement: add GET /contracts/student endpoint for Student role

### DIFF
--- a/JobMatchBackend/Controllers/ContractsController.cs
+++ b/JobMatchBackend/Controllers/ContractsController.cs
@@ -38,6 +38,27 @@ public class ContractsController : ControllerBase
         }
     }
 
+    // GET: /contracts/student?status=pending
+    [Authorize(Roles = "Student")]
+    [HttpGet("contracts/student")]
+    public async Task<IActionResult> GetStudentContracts([FromQuery] string? status)
+    {
+        try
+        {
+            var studentId = GetCurrentUserId();
+            var contracts = await _contractService.GetContractsByStudentAsync(studentId, status);
+            return Ok(contracts);
+        }
+        catch (UnauthorizedAccessException ex) when (ex.Message == "Invalid authenticated user")
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     // GET: /contracts/{contractId}
     [HttpGet("contracts/{contractId}")]
     public async Task<IActionResult> GetContractById(int contractId)

--- a/JobMatchBackend/DTOs/Response/ContractListResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ContractListResponse.cs
@@ -7,6 +7,7 @@ public class ContractListResponse
     public string JobTitle { get; set; } = string.Empty;
     public Guid IdStudent { get; set; }
     public string StudentName { get; set; } = string.Empty;
+    public string CompanyName { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime? AcceptedAt { get; set; }

--- a/JobMatchBackend/Repositories/ContractRepository.cs
+++ b/JobMatchBackend/Repositories/ContractRepository.cs
@@ -50,4 +50,19 @@ public class ContractRepository : IContractRepository
             .OrderByDescending(c => c.CreatedAt)
             .ToListAsync();
     }
+
+    public async Task<List<Contract>> GetByStudentIdAsync(Guid studentId, string? status)
+    {
+        var query = _dbContext.Contracts
+            .Include(c => c.Job)
+            .Include(c => c.Company)
+            .Where(c => c.IdStudent == studentId);
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(c => c.Status == status);
+
+        return await query
+            .OrderByDescending(c => c.CreatedAt)
+            .ToListAsync();
+    }
 }

--- a/JobMatchBackend/Repositories/IContractRepository.cs
+++ b/JobMatchBackend/Repositories/IContractRepository.cs
@@ -9,4 +9,5 @@ public interface IContractRepository
     Task<Contract?> GetContractWithDetailsAsync(int contractId);
     Task UpdateAsync(Contract contract);
     Task<List<Contract>> GetByCompanyIdAsync(Guid companyId, string? status);
+    Task<List<Contract>> GetByStudentIdAsync(Guid studentId, string? status);
 }

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -60,6 +60,23 @@ public class ContractService : IContractService
         }).ToList();
     }
 
+    public async Task<List<ContractListResponse>> GetContractsByStudentAsync(Guid studentId, string? status)
+    {
+        var contracts = await _contractRepository.GetByStudentIdAsync(studentId, status);
+
+        return contracts.Select(c => new ContractListResponse
+        {
+            IdContract = c.IdContract,
+            IdJob = c.IdJob,
+            JobTitle = c.Job?.Title ?? string.Empty,
+            IdStudent = c.IdStudent,
+            CompanyName = c.Company?.CompanyName ?? string.Empty,
+            Status = c.Status ?? string.Empty,
+            CreatedAt = c.CreatedAt,
+            AcceptedAt = c.AcceptedAt
+        }).ToList();
+    }
+
     public async Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid userId, string userRole)
     {
         var contract = await _contractRepository.GetContractWithDetailsAsync(contractId);

--- a/JobMatchBackend/Services/IContractService.cs
+++ b/JobMatchBackend/Services/IContractService.cs
@@ -6,5 +6,6 @@ public interface IContractService
 {
     Task<ContractAcceptResponse> AcceptContractAsync(int contractId, Guid studentId);
     Task<List<ContractListResponse>> GetContractsByCompanyAsync(Guid companyId, string? status);
+    Task<List<ContractListResponse>> GetContractsByStudentAsync(Guid studentId, string? status);
     Task<ContractDetailResponse> GetContractByIdAsync(int contractId, Guid userId, string userRole);
 }


### PR DESCRIPTION
# Pull Request

## Description

Implements the GET /contracts/student endpoint for listing all contracts belonging to the authenticated student. The endpoint supports optional filtering by status (pending or active) and returns company name alongside job and contract details — giving the student a full view of their contracts without needing to know individual contract IDs in advance.

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [x] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [x] Added validations
* [ ] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture

Client → ContractsController → ContractService → ContractRepository → AppDbContext → SQL Server

---

## API / Database Changes

Endpoint
GET /contracts/student — Returns all contracts for the authenticated student.
Query Parameter
status (optional) — Filter by contract status. Accepted values: pending, active. If omitted, returns all contracts.
Authorization
Requires a valid JWT token with role Student.
Response Body (List<ContractListResponse>)
Each item includes:

idContract, idJob, jobTitle
idStudent
companyName (new field added to ContractListResponse)
status, createdAt, acceptedAt
Responses
200 OK — List of contracts (empty array if none found)
401 Unauthorized — Missing or invalid token
500 Internal Server Error — Unexpected server error
Database
No migrations needed — no schema changes. The endpoint queries the existing contracts table with Include on Job and Company.

---

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [ ] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Tested GET /contracts/student with a valid Student JWT → returned 200 OK with the student's contracts list including companyName.
Tested with ?status=pending → returned only pending contracts.
Tested with ?status=active → returned only active contracts.
Tested with a Company JWT → returns 403 Forbidden (role guard enforced).
Tested with no token → returns 401 Unauthorized.
Tested with a student with no contracts → returns 200 OK with empty array [].

---

## Evidence

<img width="1600" height="726" alt="image" src="https://github.com/user-attachments/assets/09b93b0d-e8fc-4b4f-b200-403ed4188b0d" />

---

## Notes

ContractListResponse was extended with a CompanyName field to support the student view. The existing GET /contracts (Company endpoint) does not populate this field — StudentName remains the relevant field for that endpoint. Both fields coexist in the same DTO following the existing pattern.
The endpoint reads studentId directly from the JWT claims, so no path parameter is needed — consistent with how GET /contracts works for companies
