### PR TITLE
Bug/fix job bug

### DIFF
--- a/JobMatchBackend/DTOs/Response/JobDetailResponse.cs
+++ b/JobMatchBackend/DTOs/Response/JobDetailResponse.cs
@@ -10,9 +10,9 @@ public class JobDetailResponse
     public string? Status { get; set; }
     public decimal Payment { get; set; }
     public string PaymentType { get; set; } = string.Empty;
-    public DateOnly WorkDate { get; set; }
-    public TimeOnly StartTime { get; set; }
-    public TimeOnly EndTime { get; set; }
+    public DateOnly? WorkDate { get; set; }
+    public TimeOnly? StartTime { get; set; }
+    public TimeOnly? EndTime { get; set; }
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public List<string>? Deliverables { get; set; }

--- a/JobMatchBackend/DTOs/Response/JobResponse.cs
+++ b/JobMatchBackend/DTOs/Response/JobResponse.cs
@@ -5,6 +5,7 @@ public class JobResponse
     public int IdJob { get; set; }
     public Guid IdCompany { get; set; }
     public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
     public decimal Payment { get; set; }

--- a/JobMatchBackend/Mappers/JobMapper.cs
+++ b/JobMatchBackend/Mappers/JobMapper.cs
@@ -25,9 +25,9 @@ public static class JobMapper
             Description = dto.Description,
             Payment = dto.Payment,
             PaymentType = dto.PaymentType,
-            WorkDate = DateOnly.Parse(dto.Date),
-            StartTime = TimeOnly.Parse(dto.StartTime),
-            EndTime = TimeOnly.Parse(dto.EndTime),
+            WorkDate = DateOnly.TryParse(dto.Date, out var date) ? date : null,
+            StartTime = TimeOnly.TryParse(dto.StartTime, out var start) ? start : null,
+            EndTime = TimeOnly.TryParse(dto.EndTime, out var end) ? end : null,
             Type = "fixed-time",
             Status = "open"
         };
@@ -54,31 +54,30 @@ public static class JobMapper
 
     public static JobResponse ToResponse(Job job)
     {
-        var isAutonomous = string.Equals(job.Type, "autonomous", StringComparison.OrdinalIgnoreCase);
-
         return new JobResponse
         {
             IdJob = job.IdJob,
             IdCompany = job.IdCompany,
             Title = job.Title,
+            Description = job.Description,
             Type = job.Type ?? string.Empty,
             Status = job.Status ?? string.Empty,
             Payment = job.Payment,
             PaymentType = job.PaymentType,
-
-            // job.WorkDate/StartTime/EndTime are non-nullable on the entity, so for
-            // autonomous jobs (never set) we'd otherwise leak default values into the response.
-            WorkDate = isAutonomous ? null : job.WorkDate,
-            StartTime = isAutonomous ? null : job.StartTime,
-            EndTime = isAutonomous ? null : job.EndTime,
-
+            WorkDate = job.WorkDate,
+            StartTime = job.StartTime,
+            EndTime = job.EndTime,
             StartDate = job.StartDate,
             EndDate = job.EndDate,
-            Deliverables = string.IsNullOrWhiteSpace(job.Deliverables)
-                ? null
-                : JsonSerializer.Deserialize<List<string>>(job.Deliverables),
-
+            Deliverables = TryParseDeliverables(job.Deliverables),
             CreatedAt = job.CreatedAt
         };
+    }
+
+    private static List<string>? TryParseDeliverables(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try { return JsonSerializer.Deserialize<List<string>>(raw); }
+        catch { return null; }
     }
 }

--- a/JobMatchBackend/Migrations/20260618233918_MakeJobDateFieldsNullable.Designer.cs
+++ b/JobMatchBackend/Migrations/20260618233918_MakeJobDateFieldsNullable.Designer.cs
@@ -4,6 +4,7 @@ using JobMatchBackend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JobMatchBackend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618233918_MakeJobDateFieldsNullable")]
+    partial class MakeJobDateFieldsNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JobMatchBackend/Migrations/20260618233918_MakeJobDateFieldsNullable.cs
+++ b/JobMatchBackend/Migrations/20260618233918_MakeJobDateFieldsNullable.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobMatchBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeJobDateFieldsNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "WorkDate",
+                table: "jobs",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateOnly),
+                oldType: "date");
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "StartTime",
+                table: "jobs",
+                type: "time",
+                nullable: true,
+                oldClrType: typeof(TimeOnly),
+                oldType: "time");
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "EndTime",
+                table: "jobs",
+                type: "time",
+                nullable: true,
+                oldClrType: typeof(TimeOnly),
+                oldType: "time");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "WorkDate",
+                table: "jobs",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1),
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "StartTime",
+                table: "jobs",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeOnly(0, 0, 0),
+                oldClrType: typeof(TimeOnly),
+                oldType: "time",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "EndTime",
+                table: "jobs",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeOnly(0, 0, 0),
+                oldClrType: typeof(TimeOnly),
+                oldType: "time",
+                oldNullable: true);
+        }
+    }
+}

--- a/JobMatchBackend/Models/Entities/Job.cs
+++ b/JobMatchBackend/Models/Entities/Job.cs
@@ -12,9 +12,9 @@ public class Job
     
     public decimal Payment { get; set; }
     public string PaymentType { get; set; } = string.Empty;
-    public DateOnly WorkDate { get; set; }
-    public TimeOnly StartTime { get; set; }
-    public TimeOnly EndTime { get; set; }
+    public DateOnly? WorkDate { get; set; }
+    public TimeOnly? StartTime { get; set; }
+    public TimeOnly? EndTime { get; set; }
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public string? Deliverables { get; set; }

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -24,13 +24,13 @@ public class JobService : IJobService
     {
         var company = await _companyRepository.GetCompanyByIdAsync(companyId);
         if (company == null)
-            throw new KeyNotFoundException("Company not found");
+            throw new KeyNotFoundException("Empresa no encontrada.");
 
         if (!company.IsActive)
-            throw new UnauthorizedAccessException("Company is not active.");
+            throw new UnauthorizedAccessException("La empresa no está activa.");
 
         if (company.Role != "Company")
-            throw new UnauthorizedAccessException("Authenticated user is not a company.");
+            throw new UnauthorizedAccessException("Solo las empresas pueden publicar ofertas.");
 
         var errors = new List<string>();
         TimeOnly startTime = TimeOnly.MinValue;
@@ -110,7 +110,7 @@ public class JobService : IJobService
     {
         var job = await _jobRepository.GetByIdWithCompanyAsync(jobId);
         if (job == null)
-            throw new KeyNotFoundException("Job not found");
+            throw new KeyNotFoundException("Oferta no encontrada.");
 
         return new JobDetailResponse
         {
@@ -152,10 +152,10 @@ public class JobService : IJobService
     {
         var job = await _jobRepository.GetByIdWithCompanyAsync(jobId);
         if (job == null)
-            throw new KeyNotFoundException("Job not found");
+            throw new KeyNotFoundException("Oferta no encontrada.");
 
         if (job.IdCompany != companyId)
-            throw new UnauthorizedAccessException("Company does not own this job");
+            throw new UnauthorizedAccessException("No tienes permiso para modificar esta oferta.");
 
         var hasAcceptedApplications = await _jobRepository.HasAcceptedApplicationsAsync(jobId);
         if (hasAcceptedApplications)
@@ -214,17 +214,17 @@ public class JobService : IJobService
     {
         var job = await _jobRepository.GetByIdWithCompanyAsync(jobId);
         if (job == null)
-            throw new KeyNotFoundException("Job not found");
+            throw new KeyNotFoundException("Oferta no encontrada.");
 
         if (job.IdCompany != companyId)
-            throw new UnauthorizedAccessException("Company does not own this job");
+            throw new UnauthorizedAccessException("No tienes permiso para modificar esta oferta.");
 
         if (job.Status == "cancelled")
-            throw new InvalidOperationException("Job is already cancelled");
+            throw new InvalidOperationException("Esta oferta ya fue cancelada.");
 
         var hasActiveContract = await _jobRepository.HasActiveContractAsync(jobId);
         if (hasActiveContract)
-            throw new InvalidOperationException("Cannot cancel a job with an active contract");
+            throw new InvalidOperationException("No se puede cancelar una oferta con un contrato activo.");
 
         var applicantIds = await _jobRepository.GetApplicantIdsByJobIdAsync(jobId);
 

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -36,49 +36,45 @@ public class JobService : IJobService
         TimeOnly startTime = TimeOnly.MinValue;
         TimeOnly endTime = TimeOnly.MinValue;
 
-        // --- Type validation (explicit allow-list, no implicit fallback) ---
         var allowedTypes = new[] { "autonomous", "fixed-time" };
         if (string.IsNullOrWhiteSpace(request.Type) ||
             !allowedTypes.Contains(request.Type, StringComparer.OrdinalIgnoreCase))
-            errors.Add("The 'type' field is required and must be 'autonomous' or 'fixed-time'.");
+            errors.Add("El tipo de trabajo es requerido y debe ser 'autonomous' o 'fixed-time'.");
 
         var isAutonomous = string.Equals(request.Type, "autonomous", StringComparison.OrdinalIgnoreCase);
 
-        // --- Common validation (applies to every job type) ---
         if (string.IsNullOrWhiteSpace(request.Title))
-            errors.Add("The 'title' field is required.");
+            errors.Add("El título es requerido.");
 
         if (request.Payment <= 0)
-            errors.Add("The 'payment' field must be greater than 0.");
+            errors.Add("El monto debe ser mayor a 0.");
 
         var allowedPaymentTypes = new[] { "hora", "turno", "proyecto" };
         if (string.IsNullOrWhiteSpace(request.PaymentType) ||
             !allowedPaymentTypes.Contains(request.PaymentType, StringComparer.OrdinalIgnoreCase))
-            errors.Add("The 'paymentType' field must be 'hora', 'turno', or 'proyecto'.");
+            errors.Add("La modalidad de pago debe ser 'hora', 'turno' o 'proyecto'.");
 
         if (isAutonomous)
         {
-            // --- Autonomous-specific validation ---
             if (request.StartDate == null)
-                errors.Add("The 'startDate' field is required.");
+                errors.Add("La fecha de inicio es requerida.");
 
             if (request.EndDate == null)
-                errors.Add("The 'endDate' field is required.");
+                errors.Add("La fecha de fin es requerida.");
 
             if (request.Deliverables == null || request.Deliverables.Count == 0)
-                errors.Add("The 'deliverables' field is required and must contain at least one item.");
+                errors.Add("Debes agregar al menos un entregable.");
         }
         else
         {
-            // --- Fixed-time-specific validation ---
             if (string.IsNullOrWhiteSpace(request.Date) || !DateOnly.TryParse(request.Date, out _))
-                errors.Add("The 'date' field is required and must be a valid date.");
+                errors.Add("La fecha del trabajo es requerida y debe tener el formato YYYY-MM-DD.");
 
             if (string.IsNullOrWhiteSpace(request.StartTime) || !TimeOnly.TryParse(request.StartTime, out startTime))
-                errors.Add("The 'startTime' field is required and must be a valid time.");
+                errors.Add("La hora de inicio es requerida y debe tener el formato HH:mm.");
 
             if (string.IsNullOrWhiteSpace(request.EndTime) || !TimeOnly.TryParse(request.EndTime, out endTime))
-                errors.Add("The 'endTime' field is required and must be a valid time.");
+                errors.Add("La hora de fin es requerida y debe tener el formato HH:mm.");
         }
 
         if (errors.Count > 0)
@@ -86,23 +82,22 @@ public class JobService : IJobService
 
         if (isAutonomous)
         {
-            // StartDate and EndDate are guaranteed non-null past validation
             if (request.StartDate!.Value > request.EndDate!.Value)
-                throw new ArgumentException("'startDate' must be on or before 'endDate'.");
+                throw new ArgumentException("La fecha de inicio debe ser anterior o igual a la fecha de fin.");
 
             if (request.EndDate.Value < DateOnly.FromDateTime(DateTime.UtcNow))
-                throw new ArgumentException("'endDate' must be in the future.");
+                throw new ArgumentException("La fecha de fin debe ser en el futuro.");
         }
         else
         {
             if (DateTime.TryParse(request.Date + " " + request.StartTime, out var jobDateTime))
             {
                 if (jobDateTime <= DateTime.UtcNow)
-                    throw new ArgumentException("The job date and time must be in the future.");
+                    throw new ArgumentException("La fecha y hora del trabajo deben ser en el futuro.");
             }
 
             if (startTime >= endTime)
-                throw new ArgumentException("'startTime' must be before 'endTime'.");
+                throw new ArgumentException("La hora de inicio debe ser anterior a la hora de fin.");
         }
 
         var job = JobMapper.ToEntity(request);
@@ -164,11 +159,11 @@ public class JobService : IJobService
 
         var hasAcceptedApplications = await _jobRepository.HasAcceptedApplicationsAsync(jobId);
         if (hasAcceptedApplications)
-            throw new InvalidOperationException("Cannot edit a job that has accepted students");
+            throw new InvalidOperationException("No se puede editar una oferta que ya tiene postulantes aceptados.");
 
         var hasActiveContract = await _jobRepository.HasActiveContractAsync(jobId);
         if (hasActiveContract)
-            throw new InvalidOperationException("Cannot edit a job with an active contract");
+            throw new InvalidOperationException("No se puede editar una oferta con un contrato activo.");
 
         if (!string.IsNullOrWhiteSpace(request.Title)) job.Title = request.Title;
         if (!string.IsNullOrWhiteSpace(request.Description)) job.Description = request.Description;

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -123,7 +123,7 @@ public class JobService : IJobService
             IdCompany = job.IdCompany,
             Title = job.Title,
             Description = job.Description,
-            Type = job.Type,
+            Type = job.Type ?? string.Empty,
             Status = job.Status,
             Payment = job.Payment,
             PaymentType = job.PaymentType,
@@ -132,9 +132,7 @@ public class JobService : IJobService
             EndTime = job.EndTime,
             StartDate = job.StartDate,
             EndDate = job.EndDate,
-            Deliverables = string.IsNullOrWhiteSpace(job.Deliverables)
-                ? null
-                : JsonSerializer.Deserialize<List<string>>(job.Deliverables),
+            Deliverables = TryParseDeliverables(job.Deliverables),
             CreatedAt = job.CreatedAt,
             UpdatedAt = job.UpdatedAt,
             Company = new CompanySummaryResponse
@@ -193,7 +191,7 @@ public class JobService : IJobService
             IdCompany = updated.IdCompany,
             Title = updated.Title,
             Description = updated.Description,
-            Type = updated.Type,
+            Type = updated.Type ?? string.Empty,
             Status = updated.Status,
             Payment = updated.Payment,
             PaymentType = updated.PaymentType,
@@ -202,9 +200,7 @@ public class JobService : IJobService
             EndTime = updated.EndTime,
             StartDate = updated.StartDate,
             EndDate = updated.EndDate,
-            Deliverables = string.IsNullOrWhiteSpace(updated.Deliverables)
-                ? null
-                : JsonSerializer.Deserialize<List<string>>(updated.Deliverables),
+            Deliverables = TryParseDeliverables(updated.Deliverables),
             CreatedAt = updated.CreatedAt,
             UpdatedAt = updated.UpdatedAt,
             Company = new CompanySummaryResponse
@@ -254,5 +250,12 @@ public class JobService : IJobService
 
             await _notificationRepository.CreateManyAsync(notifications);
         }
+    }
+
+    private static List<string>? TryParseDeliverables(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try { return JsonSerializer.Deserialize<List<string>>(raw); }
+        catch { return null; }
     }
 }

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -51,9 +51,10 @@ public class JobService : IJobService
         if (request.Payment <= 0)
             errors.Add("The 'payment' field must be greater than 0.");
 
+        var allowedPaymentTypes = new[] { "hora", "turno", "proyecto" };
         if (string.IsNullOrWhiteSpace(request.PaymentType) ||
-            (request.PaymentType != "one_time" && request.PaymentType != "monthly"))
-            errors.Add("The 'paymentType' field must be 'one_time' or 'monthly'.");
+            !allowedPaymentTypes.Contains(request.PaymentType, StringComparer.OrdinalIgnoreCase))
+            errors.Add("The 'paymentType' field must be 'hora', 'turno', or 'proyecto'.");
 
         if (isAutonomous)
         {


### PR DESCRIPTION
 # Pull Request

  ## Description

  This PR fixes a series of bugs that caused `POST /jobs` to return `400 Bad Request` for autonomous jobs and `GET /jobs` to crash when any job had malformed
  deliverables data. It also adds full autonomous job support to the job creation and detail flows.

  The root causes were: `WorkDate`, `StartTime`, and `EndTime` were declared non-nullable in both the entity and DTOs even though autonomous jobs never set
  those fields; `Deliverables` was deserialized from JSON without a try-catch, crashing the entire jobs list if one record had corrupted data; and `paymentType`
  validation rejected the values the frontend actually sends.

  ---

  ## Related Issue

  Closes #IssueNumber

  ---

  ## Changes Included

  ### Backend Changes

  * [ ] Added new endpoint(s)
  * [x] Added/updated DTOs
  * [x] Added/updated services
  * [ ] Added/updated repositories
  * [x] Added/updated database migrations
  * [x] Added validations
  * [x] Added exception handling
  * [ ] Other:

  ---

  ## Architecture

  No architectural changes. All modifications follow the existing pattern:

  Controller → Service → Repository → Database

  Validation and business rules remain in the service layer. Response shaping stays in the mapper. Database access is unchanged.

  ---

  ## API / Database Changes

  ### Entity — `Job.cs`

  `WorkDate`, `StartTime`, and `EndTime` changed from non-nullable structs (`DateOnly`, `TimeOnly`) to nullable (`DateOnly?`, `TimeOnly?`). Autonomous jobs
  leave these fields null; fixed-time jobs populate them.

  ### DTOs

  **`JobResponse.cs`** — `WorkDate`, `StartTime`, `EndTime` made nullable. Added missing fields: `Description`, `StartDate`, `EndDate`, `Deliverables`
  (`List<string>?`).

  **`JobDetailResponse.cs`** — `WorkDate`, `StartTime`, `EndTime` made nullable. `Deliverables` changed from `string?` to `List<string>?` to match the
  serialized format.

  ### Mapper — `JobMapper.cs`

  `ToEntity` now dispatches to `ToFixedTimeEntity` or `ToAutonomousEntity` based on `dto.Type`, instead of hardcoding `"fixed-time"`. `ToResponse` includes all
  new fields. `Deliverables` deserialization moved to a private `TryParseDeliverables` method with a try-catch so a single corrupted record no longer crashes
  the full list.

  ### Service — `JobService.cs`

  - `paymentType` validation updated from `"one_time"/"monthly"` to `"hora"/"turno"/"proyecto"`.
  - All user-facing validation and exception messages translated to Spanish.
  - `TryParseDeliverables` helper added and used in both `GetJobByIdAsync` and `UpdateJobAsync`.
  - Null coalescing added for `job.Type` assignment (`?? string.Empty`) to resolve nullable warnings.
  - `UpdateJobAsync` and `CancelJobAsync` exception messages translated to Spanish.

  ### Migration — `20260618233918_MakeJobDateFieldsNullable`

  Alters `WorkDate`, `StartTime`, and `EndTime` columns in the `jobs` table from `NOT NULL` to `NULL` to match the updated entity.

  ```sql
  ALTER TABLE [jobs] ALTER COLUMN [WorkDate] date NULL;
  ALTER TABLE [jobs] ALTER COLUMN [StartTime] time NULL;
  ALTER TABLE [jobs] ALTER COLUMN [EndTime] time NULL;
```
  ---
  Testing Performed

  - [x] Feature tested manually
  - [ ] Navigation tested
  - [x] Error handling tested
  - [x] Validation tested
  - [x] Backend integration tested
  - [x] No crashes detected

  Test Details

  - POST /jobs with type: "autonomous" and startDate/endDate creates successfully. Previously returned 400 due to NOT NULL constraint on EndTime.
  - GET /jobs returns the full list including autonomous jobs. Previously returned 400 when any job had malformed Deliverables JSON.
  - GET /jobs/{id} returns deliverables as a JSON array. Previously returned a string or null.
  - Validation errors for missing/invalid date and time fields return descriptive Spanish messages instead of a generic 400.
  - paymentType values "hora", "turno", and "proyecto" are now accepted. Previously rejected with a 400.
  - dotnet build completed successfully with no new errors.

  ---
  Notes

  Migration required: after merging, run dotnet ef database update to apply the nullable column changes. Without this the POST /jobs for autonomous jobs will
  continue to fail with a SQL NOT NULL constraint error.

  UpdateJobRequest does not include type or autonomous-specific fields yet — editing an autonomous job's dates is out of scope for this PR.
  