### PR TITLE
feat: add GET /jobs/recommended endpoint for students (issue #13)

### DIFF
--- a/JobMatchBackend/Controllers/JobsController.cs
+++ b/JobMatchBackend/Controllers/JobsController.cs
@@ -17,7 +17,27 @@ public class JobsController : ControllerBase
         _jobService = jobService;
     }
 
-    [HttpGet("{jobId}")]
+    [Authorize(Roles = "Student")]
+    [HttpGet("recommended")]
+    public async Task<IActionResult> GetRecommendedJobs()
+    {
+        try
+        {
+            var studentId = GetCurrentUserId();
+            var jobs = await _jobService.GetRecommendedJobsAsync(studentId);
+            return Ok(jobs);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
+    [HttpGet("{jobId:int}")]
     public async Task<IActionResult> GetJobById(int jobId)
     {
         try

--- a/JobMatchBackend/DTOs/Request/UpdateJobRequest.cs
+++ b/JobMatchBackend/DTOs/Request/UpdateJobRequest.cs
@@ -12,4 +12,5 @@ public class UpdateJobRequest
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public List<string>? Deliverables { get; set; }
+    public List<string>? SkillsRequired { get; set; }
 }

--- a/JobMatchBackend/DTOs/Response/JobDetailResponse.cs
+++ b/JobMatchBackend/DTOs/Response/JobDetailResponse.cs
@@ -16,6 +16,7 @@ public class JobDetailResponse
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public List<string>? Deliverables { get; set; }
+    public List<string>? SkillsRequired { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
     public CompanySummaryResponse Company { get; set; } = new();

--- a/JobMatchBackend/DTOs/Response/JobResponse.cs
+++ b/JobMatchBackend/DTOs/Response/JobResponse.cs
@@ -20,6 +20,7 @@ public class JobResponse
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public List<string>? Deliverables { get; set; }
+    public List<string>? SkillsRequired { get; set; }
 
     public DateTime CreatedAt { get; set; }
 }

--- a/JobMatchBackend/Mappers/JobMapper.cs
+++ b/JobMatchBackend/Mappers/JobMapper.cs
@@ -29,7 +29,8 @@ public static class JobMapper
             StartTime = TimeOnly.TryParse(dto.StartTime, out var start) ? start : null,
             EndTime = TimeOnly.TryParse(dto.EndTime, out var end) ? end : null,
             Type = "fixed-time",
-            Status = "open"
+            Status = "open",
+            SkillsRequired = dto.SkillsRequired != null ? JsonSerializer.Serialize(dto.SkillsRequired) : null
         };
     }
 
@@ -48,7 +49,8 @@ public static class JobMapper
             EndDate = dto.EndDate,
             Deliverables = dto.Deliverables != null ? JsonSerializer.Serialize(dto.Deliverables) : null,
             Type = "autonomous",
-            Status = "open"
+            Status = "open",
+            SkillsRequired = dto.SkillsRequired != null ? JsonSerializer.Serialize(dto.SkillsRequired) : null
         };
     }
 
@@ -70,11 +72,19 @@ public static class JobMapper
             StartDate = job.StartDate,
             EndDate = job.EndDate,
             Deliverables = TryParseDeliverables(job.Deliverables),
+            SkillsRequired = TryParseSkillsRequired(job.SkillsRequired),
             CreatedAt = job.CreatedAt
         };
     }
 
     private static List<string>? TryParseDeliverables(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try { return JsonSerializer.Deserialize<List<string>>(raw); }
+        catch { return null; }
+    }
+
+    private static List<string>? TryParseSkillsRequired(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return null;
         try { return JsonSerializer.Deserialize<List<string>>(raw); }

--- a/JobMatchBackend/Migrations/20260619041157_AddSkillsRequiredToJob.Designer.cs
+++ b/JobMatchBackend/Migrations/20260619041157_AddSkillsRequiredToJob.Designer.cs
@@ -4,6 +4,7 @@ using JobMatchBackend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JobMatchBackend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619041157_AddSkillsRequiredToJob")]
+    partial class AddSkillsRequiredToJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JobMatchBackend/Migrations/20260619041157_AddSkillsRequiredToJob.cs
+++ b/JobMatchBackend/Migrations/20260619041157_AddSkillsRequiredToJob.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobMatchBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSkillsRequiredToJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SkillsRequired",
+                table: "jobs",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SkillsRequired",
+                table: "jobs");
+        }
+    }
+}

--- a/JobMatchBackend/Models/Entities/Job.cs
+++ b/JobMatchBackend/Models/Entities/Job.cs
@@ -18,7 +18,8 @@ public class Job
     public DateOnly? StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
     public string? Deliverables { get; set; }
-    
+    public string? SkillsRequired { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
 

--- a/JobMatchBackend/Repositories/IJobRepository.cs
+++ b/JobMatchBackend/Repositories/IJobRepository.cs
@@ -14,4 +14,5 @@ public interface IJobRepository
     Task<bool> HasActiveContractAsync(int jobId);
     Task<Job> CancelAsync(Job job);
     Task<List<Guid>> GetApplicantIdsByJobIdAsync(int jobId);
+    Task<List<Job>> GetOpenJobsAsync();
 }

--- a/JobMatchBackend/Repositories/JobRepository.cs
+++ b/JobMatchBackend/Repositories/JobRepository.cs
@@ -89,4 +89,12 @@ public class JobRepository : IJobRepository
             .Select(a => a.IdStudent)
             .ToListAsync();
     }
+
+    public async Task<List<Job>> GetOpenJobsAsync()
+    {
+        return await _dbContext.Jobs
+            .Include(j => j.Company)
+            .Where(j => j.Status == "open" && j.Company != null && j.Company.IsActive)
+            .ToListAsync();
+    }
 }

--- a/JobMatchBackend/Services/IJobService.cs
+++ b/JobMatchBackend/Services/IJobService.cs
@@ -10,4 +10,5 @@ public interface IJobService
     Task<JobDetailResponse> GetJobByIdAsync(int jobId);
     Task<JobDetailResponse> UpdateJobAsync(int jobId, Guid companyId, UpdateJobRequest request);
     Task CancelJobAsync(int jobId, Guid companyId);
+    Task<List<JobResponse>> GetRecommendedJobsAsync(Guid studentId);
 }

--- a/JobMatchBackend/Services/JobService.cs
+++ b/JobMatchBackend/Services/JobService.cs
@@ -12,12 +12,14 @@ public class JobService : IJobService
     private readonly IJobRepository _jobRepository;
     private readonly INotificationRepository _notificationRepository;
     private readonly ICompanyRepository _companyRepository;
+    private readonly IStudentRepository _studentRepository;
 
-    public JobService(IJobRepository jobRepository, INotificationRepository notificationRepository, ICompanyRepository companyRepository)
+    public JobService(IJobRepository jobRepository, INotificationRepository notificationRepository, ICompanyRepository companyRepository, IStudentRepository studentRepository)
     {
         _jobRepository = jobRepository;
         _notificationRepository = notificationRepository;
         _companyRepository = companyRepository;
+        _studentRepository = studentRepository;
     }
 
     public async Task<JobResponse> CreateJobAsync(Guid companyId, CreateJobRequest request)
@@ -128,6 +130,7 @@ public class JobService : IJobService
             StartDate = job.StartDate,
             EndDate = job.EndDate,
             Deliverables = TryParseDeliverables(job.Deliverables),
+            SkillsRequired = TryParseSkillsRequired(job.SkillsRequired),
             CreatedAt = job.CreatedAt,
             UpdatedAt = job.UpdatedAt,
             Company = new CompanySummaryResponse
@@ -175,6 +178,7 @@ public class JobService : IJobService
         if (request.StartDate != null) job.StartDate = request.StartDate;
         if (request.EndDate != null) job.EndDate = request.EndDate;
         if (request.Deliverables != null) job.Deliverables = JsonSerializer.Serialize(request.Deliverables);
+        if (request.SkillsRequired != null) job.SkillsRequired = JsonSerializer.Serialize(request.SkillsRequired);
 
         job.UpdatedAt = DateTime.UtcNow;
 
@@ -196,6 +200,7 @@ public class JobService : IJobService
             StartDate = updated.StartDate,
             EndDate = updated.EndDate,
             Deliverables = TryParseDeliverables(updated.Deliverables),
+            SkillsRequired = TryParseSkillsRequired(updated.SkillsRequired),
             CreatedAt = updated.CreatedAt,
             UpdatedAt = updated.UpdatedAt,
             Company = new CompanySummaryResponse
@@ -247,7 +252,55 @@ public class JobService : IJobService
         }
     }
 
+    public async Task<List<JobResponse>> GetRecommendedJobsAsync(Guid studentId)
+    {
+        var student = await _studentRepository.GetByIdAsync(studentId);
+        if (student == null)
+            throw new KeyNotFoundException("Estudiante no encontrado.");
+
+        var openJobs = await _jobRepository.GetOpenJobsAsync();
+
+        var studentSkillNames = student.StudentSkills?
+            .Select(ss => ss.Skill?.Name ?? string.Empty)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>();
+
+        var recommended = openJobs.Where(job =>
+        {
+            if (string.Equals(job.Type, "fixed-time", StringComparison.OrdinalIgnoreCase))
+            {
+                if (job.WorkDate == null || job.StartTime == null || job.EndTime == null)
+                    return false;
+
+                var dayOfWeek = (int)job.WorkDate.Value.DayOfWeek;
+                return student.Availabilities != null && student.Availabilities.Any(slot =>
+                    slot.DayOfWeek == dayOfWeek &&
+                    slot.StartTime <= job.StartTime.Value &&
+                    slot.EndTime >= job.EndTime.Value);
+            }
+
+            if (string.Equals(job.Type, "autonomous", StringComparison.OrdinalIgnoreCase))
+            {
+                var requiredSkills = TryParseSkillsRequired(job.SkillsRequired);
+                if (requiredSkills == null || requiredSkills.Count == 0)
+                    return true;
+
+                return requiredSkills.Any(s => studentSkillNames.Contains(s));
+            }
+
+            return false;
+        }).ToList();
+
+        return recommended.Select(JobMapper.ToResponse).ToList();
+    }
+
     private static List<string>? TryParseDeliverables(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try { return JsonSerializer.Deserialize<List<string>>(raw); }
+        catch { return null; }
+    }
+
+    private static List<string>? TryParseSkillsRequired(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return null;
         try { return JsonSerializer.Deserialize<List<string>>(raw); }


### PR DESCRIPTION
# Pull Request

## Description

Adds the `GET /jobs/recommended` endpoint for authenticated students (issue #13). The recommendation engine filters open jobs by matching each student's configured weekly availability and registered skills against the job requirements stored in the database.

For **fixed-time** jobs the engine checks that the job's work date falls on a weekday the student has marked as available and that at least one of their availability slots covers the full job time window (`slot.StartTime ≤ job.StartTime` and `slot.EndTime ≥ job.EndTime`).

For **autonomous** jobs the engine deserializes the job's `SkillsRequired` list and verifies that the student has at least one matching skill (case-insensitive). If no skills are required the job is always included.

Because `SkillsRequired` was accepted by `CreateJobRequest` but never persisted, this PR also adds the `SkillsRequired` column (`nvarchar(max) NULL`) to the `jobs` table via a new EF Core migration, wires it through `JobMapper`, and surfaces it in `JobResponse` and `JobDetailResponse`. Existing rows receive `NULL` and no existing functionality is affected.

## Related Issue

Closes #13

## Changes Included

### Backend Changes

* [x] Added new endpoint(s): `GET /jobs/recommended`
* [x] Added/updated DTOs: `JobResponse`, `JobDetailResponse`, `UpdateJobRequest` — added `List<string>? SkillsRequired`
* [x] Added/updated services: `IJobService.GetRecommendedJobsAsync`, `JobService` implementation with availability + skill filtering; injected `IStudentRepository`
* [x] Added/updated repositories: `IJobRepository`/`JobRepository` — added `GetOpenJobsAsync`
* [x] Added database migrations: `20260619041157_AddSkillsRequiredToJob` — adds `SkillsRequired nvarchar(max) NULL` to `jobs`
* [x] Added validations: student existence check; null-guard on `WorkDate`/`StartTime`/`EndTime` before filtering fixed-time jobs
* [x] Added exception handling: `KeyNotFoundException → 404`, generic `Exception → 500`
* [x] Other: added `:int` route constraint to `{jobId}` to prevent routing ambiguity with the new named route; `[Authorize(Roles = "Student")]` on the new endpoint

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

## Architecture

Follows the same layering used throughout the project: `JobsController → JobService → JobRepository / StudentRepository → AppDbContext`. Filtering logic lives entirely in `JobService` (business rules belong in the service layer, not in repositories or controllers), consistent with how job creation validation and contract ownership checks are structured in the existing codebase. `StudentRepository.GetByIdAsync` already eager-loads `Availabilities` and `StudentSkills.ThenInclude(Skill)` in a single query, so no additional query overhead was introduced for the student side.

## API / Database Changes

New endpoint: `GET /jobs/recommended`

* Auth: `Bearer` token required, role must be `Student`
* Response: `200 OK` with `List<JobResponse>` (same shape as `GET /jobs`, now includes `skillsRequired` field)
* Status codes: `200` on success; `401` if token is missing or invalid; `403` if the authenticated user is not a Student; `404` if the student record is not found; `500` for unexpected errors

Migration: `20260619041157_AddSkillsRequiredToJob`
* Adds `SkillsRequired nvarchar(max) NULL` to `jobs` table
* Non-breaking: existing rows get `NULL`, no data loss, no existing queries affected

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [ ] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

- `GET /jobs/recommended` without token → `401`
- `GET /jobs/recommended` with a Company token → `403` (role check)
- `GET /jobs/recommended` with a Student token whose availability matches a fixed-time open job → job appears in response
- `GET /jobs/recommended` with a Student token whose skills match an autonomous open job's `SkillsRequired` → job appears in response
- Autonomous job with no `SkillsRequired` → included for all students
- Happy path: `200` with correctly filtered `JobResponse` list including `skillsRequired` field

## Evidence
<img width="1600" height="726" alt="image" src="https://github.com/user-attachments/assets/6e4b16d8-a520-469d-bd6c-ad52c8268a4c" />

## Notes

`SkillsRequired` was already accepted by `CreateJobRequest` in the existing codebase but was silently dropped by `JobMapper` and never stored. This PR fixes that gap as a prerequisite for the recommendation filter to work. The change is purely additive and does not alter any existing endpoint behavior.