### PR TITLE
feat: add POST /ratings endpoint and wire real AverageRating to stude…

### DIFF
--- a/JobMatchBackend/Controllers/RatingsController.cs
+++ b/JobMatchBackend/Controllers/RatingsController.cs
@@ -1,0 +1,72 @@
+using JobMatchBackend.DTOs.Request;
+using JobMatchBackend.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace JobMatchBackend.Controllers;
+
+[ApiController]
+[Route("ratings")]
+[Authorize]
+public class RatingsController : ControllerBase
+{
+    private readonly IRatingService _ratingService;
+
+    public RatingsController(IRatingService ratingService)
+    {
+        _ratingService = ratingService;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> CreateRating([FromBody] CreateRatingRequest request)
+    {
+        Guid callerId;
+        try
+        {
+            callerId = GetCurrentUserId();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+
+        try
+        {
+            var response = await _ratingService.CreateRatingAsync(request, callerId);
+            return StatusCode(201, response);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(403, new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            var status = ex.Message.Contains("Ya calificaste") ? 409 : 400;
+            return StatusCode(status, new { message = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
+    private Guid GetCurrentUserId()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userId, out var parsedId))
+            throw new UnauthorizedAccessException("Usuario autenticado inválido.");
+        return parsedId;
+    }
+}

--- a/JobMatchBackend/DTOs/Request/CreateRatingRequest.cs
+++ b/JobMatchBackend/DTOs/Request/CreateRatingRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JobMatchBackend.DTOs.Request;
+
+public class CreateRatingRequest
+{
+    [Range(1, int.MaxValue, ErrorMessage = "El ID del contrato no es válido.")]
+    public int IdContract { get; set; }
+
+    [Range(1, 5, ErrorMessage = "La calificación debe ser entre 1 y 5 estrellas.")]
+    public int Stars { get; set; }
+
+    public string? Comment { get; set; }
+}

--- a/JobMatchBackend/DTOs/Response/RatingResponse.cs
+++ b/JobMatchBackend/DTOs/Response/RatingResponse.cs
@@ -1,0 +1,11 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class RatingResponse
+{
+    public int IdRating { get; set; }
+    public int IdContract { get; set; }
+    public Guid IdRated { get; set; }
+    public int Stars { get; set; }
+    public string? Comment { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/JobMatchBackend/Mappers/StudentMapper.cs
+++ b/JobMatchBackend/Mappers/StudentMapper.cs
@@ -6,7 +6,7 @@ namespace JobMatchBackend.Mappers;
 
 public static class StudentMapper
 {
-    public static StudentProfileResponse ToResponse(User user)
+    public static StudentProfileResponse ToResponse(User user, float averageRating = 0.0f)
     {
         return new StudentProfileResponse
         {
@@ -29,7 +29,7 @@ public static class StudentMapper
                 .Select(ss => new StudentSkillResponse { SkillId = ss.Skill!.Id, SkillName = ss.Skill!.Name })
                 .ToList() ?? new List<StudentSkillResponse>(),
             Availability = ToAvailabilityResponse(user),
-            AverageRating = 0.0f
+            AverageRating = averageRating
         };
     }
 

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<ICompanyRepository, CompanyRepository>();
 builder.Services.AddScoped<IStudentRepository, StudentRepository>();
 builder.Services.AddScoped<ISkillRepository, SkillRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
+builder.Services.AddScoped<IRatingRepository, RatingRepository>();
 builder.Services.AddScoped<INotificationRepository, NotificationRepository>();
 
 // Services
@@ -59,6 +60,7 @@ builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddScoped<IContractService, ContractService>();
 builder.Services.AddScoped<ISkillService, SkillService>();
 builder.Services.AddScoped<IPaymentService, PaymentService>();
+builder.Services.AddScoped<IRatingService, RatingService>();
 
 // Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/JobMatchBackend/Repositories/IRatingRepository.cs
+++ b/JobMatchBackend/Repositories/IRatingRepository.cs
@@ -1,0 +1,11 @@
+using JobMatchBackend.Models.Entities;
+
+namespace JobMatchBackend.Repositories;
+
+public interface IRatingRepository
+{
+    Task<Contract?> GetContractByIdAsync(int contractId);
+    Task<bool> HasRatedAsync(int contractId, Guid raterId);
+    Task<Rating> AddAsync(Rating rating);
+    Task<float> GetAverageRatingAsync(Guid userId);
+}

--- a/JobMatchBackend/Repositories/RatingRepository.cs
+++ b/JobMatchBackend/Repositories/RatingRepository.cs
@@ -1,0 +1,45 @@
+using JobMatchBackend.Data;
+using JobMatchBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace JobMatchBackend.Repositories;
+
+public class RatingRepository : IRatingRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public RatingRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Contract?> GetContractByIdAsync(int contractId)
+    {
+        return await _dbContext.Contracts
+            .FirstOrDefaultAsync(c => c.IdContract == contractId);
+    }
+
+    public async Task<bool> HasRatedAsync(int contractId, Guid raterId)
+    {
+        return await _dbContext.Ratings
+            .AnyAsync(r => r.IdContract == contractId && r.IdRater == raterId);
+    }
+
+    public async Task<Rating> AddAsync(Rating rating)
+    {
+        _dbContext.Ratings.Add(rating);
+        await _dbContext.SaveChangesAsync();
+        return rating;
+    }
+
+    public async Task<float> GetAverageRatingAsync(Guid userId)
+    {
+        var ratings = await _dbContext.Ratings
+            .Where(r => r.IdRated == userId)
+            .ToListAsync();
+
+        if (ratings.Count == 0) return 0.0f;
+
+        return (float)ratings.Average(r => r.Stars);
+    }
+}

--- a/JobMatchBackend/Services/IRatingService.cs
+++ b/JobMatchBackend/Services/IRatingService.cs
@@ -1,0 +1,9 @@
+using JobMatchBackend.DTOs.Request;
+using JobMatchBackend.DTOs.Response;
+
+namespace JobMatchBackend.Services;
+
+public interface IRatingService
+{
+    Task<RatingResponse> CreateRatingAsync(CreateRatingRequest request, Guid callerId);
+}

--- a/JobMatchBackend/Services/RatingService.cs
+++ b/JobMatchBackend/Services/RatingService.cs
@@ -1,0 +1,62 @@
+using JobMatchBackend.DTOs.Request;
+using JobMatchBackend.DTOs.Response;
+using JobMatchBackend.Models.Entities;
+using JobMatchBackend.Repositories;
+
+namespace JobMatchBackend.Services;
+
+public class RatingService : IRatingService
+{
+    private readonly IRatingRepository _ratingRepository;
+
+    public RatingService(IRatingRepository ratingRepository)
+    {
+        _ratingRepository = ratingRepository;
+    }
+
+    public async Task<RatingResponse> CreateRatingAsync(CreateRatingRequest request, Guid callerId)
+    {
+        if (request.Stars <= 2 && string.IsNullOrWhiteSpace(request.Comment))
+            throw new InvalidOperationException("El comentario es obligatorio cuando la calificación es de 1 o 2 estrellas.");
+
+        var contract = await _ratingRepository.GetContractByIdAsync(request.IdContract);
+        if (contract == null)
+            throw new KeyNotFoundException("Contrato no encontrado.");
+
+        var isStudent = contract.IdStudent == callerId;
+        var isCompany = contract.IdCompany == callerId;
+
+        if (!isStudent && !isCompany)
+            throw new UnauthorizedAccessException("No tienes permiso para calificar este contrato.");
+
+        if (!string.Equals(contract.Status, "active", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Solo se pueden calificar contratos activos.");
+
+        var alreadyRated = await _ratingRepository.HasRatedAsync(request.IdContract, callerId);
+        if (alreadyRated)
+            throw new InvalidOperationException("Ya calificaste este contrato.");
+
+        var idRated = isStudent ? contract.IdCompany : contract.IdStudent;
+
+        var rating = new Rating
+        {
+            IdContract = request.IdContract,
+            IdRater = callerId,
+            IdRated = idRated,
+            Stars = request.Stars,
+            Comment = request.Comment
+        };
+
+        var created = await _ratingRepository.AddAsync(rating);
+
+        return new RatingResponse
+        {
+            IdRating = created.IdRating,
+            IdContract = created.IdContract,
+            IdRated = created.IdRated,
+            Stars = created.Stars,
+            Comment = created.Comment,
+            CreatedAt = created.CreatedAt
+        };
+    }
+}

--- a/JobMatchBackend/Services/StudentService.cs
+++ b/JobMatchBackend/Services/StudentService.cs
@@ -9,10 +9,12 @@ namespace JobMatchBackend.Services;
 public class StudentService : IStudentService
 {
     private readonly IStudentRepository _studentRepository;
+    private readonly IRatingRepository _ratingRepository;
 
-    public StudentService(IStudentRepository studentRepository)
+    public StudentService(IStudentRepository studentRepository, IRatingRepository ratingRepository)
     {
         _studentRepository = studentRepository;
+        _ratingRepository = ratingRepository;
     }
 
     public async Task<StudentProfileResponse> GetStudentByIdAsync(Guid studentId)
@@ -21,7 +23,8 @@ public class StudentService : IStudentService
         if (student == null)
             throw new KeyNotFoundException("Student not found");
 
-        return StudentMapper.ToResponse(student);
+        var averageRating = await _ratingRepository.GetAverageRatingAsync(studentId);
+        return StudentMapper.ToResponse(student, averageRating);
     }
 
     public async Task<AvailabilityResponse> GetStudentAvailabilityAsync(Guid studentId)


### PR DESCRIPTION
# Pull Request

## Description

Implements POST /ratings. An authenticated user who is part of an
active contract can rate the other party once with 1–5 stars and an optional
comment. Comment is mandatory when stars is 1 or 2. Duplicate ratings return 409.
Also wires the existing AverageRating field in the student profile to return a
real average from the ratings table instead of the hardcoded 0.0.

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s): POST /ratings
* [x] Added/updated DTOs: CreateRatingRequest, RatingResponse
* [x] Added/updated services: IRatingService / RatingService; StudentService now
      injects IRatingRepository to compute real AverageRating
* [x] Added/updated repositories: IRatingRepository / RatingRepository
* [x] Added validations: stars 1–5, comment required when stars <= 2, contract
      exists, caller is party to the contract, contract is active, no duplicate
* [x] Added exception handling: 400, 401, 403, 404, 409, 500

---

## API / Database Changes

POST /ratings — no schema changes, ratings table already existed.

Request:
{
  "idContract": 1,
  "stars": 4,
  "comment": "Muy buen trabajo"
}

Response 201:
{
  "idRating": 3,
  "idContract": 1,
  "idRated": "a1b2c3d4-...",
  "stars": 4,
  "comment": "Muy buen trabajo",
  "createdAt": "2026-06-19T14:23:00Z"
}

---

## Testing Performed

* [x] Feature tested manually
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

---

## Evidence

<img width="1600" height="763" alt="image" src="https://github.com/user-attachments/assets/6816ecff-eadc-4221-887d-4cf1ebc1f93f" />