### PR TITLE
Feature/configure push notifications issue#84

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ JobMatchBackend/appsettings.json
 JobMatchBackend/appsettings.Development.json
 JobMatchBackend/appsettings.Production.json
 JobMatchBackend/appsettings.Staging.json
+**/firebase-adminsdk*.json
+**/serviceAccountKey*.json
+**/google-services*.json

--- a/JobMatchBackend/Controllers/FcmTokensController.cs
+++ b/JobMatchBackend/Controllers/FcmTokensController.cs
@@ -1,0 +1,47 @@
+using JobMatchBackend.DTOs.Request;
+using JobMatchBackend.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace JobMatchBackend.Controllers;
+
+[ApiController]
+[Route("notifications")]
+[Authorize]
+public class FcmTokensController : ControllerBase
+{
+    private readonly IFcmTokenRepository _fcmTokenRepository;
+
+    public FcmTokensController(IFcmTokenRepository fcmTokenRepository)
+    {
+        _fcmTokenRepository = fcmTokenRepository;
+    }
+
+    [HttpPost("token")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> RegisterToken([FromBody] RegisterFcmTokenRequest request)
+    {
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized(new { message = "Usuario autenticado inválido." });
+
+        await _fcmTokenRepository.SaveOrUpdateAsync(userId.Value, request.Token, request.DeviceInfo);
+        return Ok(new { message = "Token registrado correctamente." });
+    }
+
+    [HttpDelete("token/{token}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> DeleteToken(string token)
+    {
+        await _fcmTokenRepository.DeleteByTokenAsync(token);
+        return NoContent();
+    }
+
+    private Guid? GetCurrentUserId()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(userId, out var parsed) ? parsed : null;
+    }
+}

--- a/JobMatchBackend/DTOs/Request/RegisterFcmTokenRequest.cs
+++ b/JobMatchBackend/DTOs/Request/RegisterFcmTokenRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JobMatchBackend.DTOs.Request;
+
+public class RegisterFcmTokenRequest
+{
+    [Required(ErrorMessage = "El token FCM es requerido.")]
+    public string Token { get; set; } = string.Empty;
+
+    public string? DeviceInfo { get; set; }
+}

--- a/JobMatchBackend/JobMatchBackend.csproj
+++ b/JobMatchBackend/JobMatchBackend.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="FirebaseAdmin" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/JobMatchBackend/Program.cs
+++ b/JobMatchBackend/Program.cs
@@ -1,3 +1,5 @@
+using FirebaseAdmin;
+using Google.Apis.Auth.OAuth2;
 using JobMatchBackend.Data;
 using JobMatchBackend.Repositories;
 using JobMatchBackend.Services;
@@ -8,6 +10,16 @@ using Microsoft.OpenApi.Models;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Firebase Admin SDK initialization
+var credentialPath = builder.Configuration["Firebase:CredentialPath"];
+if (!string.IsNullOrWhiteSpace(credentialPath) && File.Exists(credentialPath))
+{
+    FirebaseApp.Create(new AppOptions
+    {
+        Credential = GoogleCredential.FromFile(credentialPath)
+    });
+}
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
@@ -49,6 +61,7 @@ builder.Services.AddScoped<ISkillRepository, SkillRepository>();
 builder.Services.AddScoped<IPaymentRepository, PaymentRepository>();
 builder.Services.AddScoped<IRatingRepository, RatingRepository>();
 builder.Services.AddScoped<INotificationRepository, NotificationRepository>();
+builder.Services.AddScoped<IFcmTokenRepository, FcmTokenRepository>();
 
 // Services
 builder.Services.AddScoped<IApplicationService, ApplicationService>();
@@ -61,6 +74,7 @@ builder.Services.AddScoped<IContractService, ContractService>();
 builder.Services.AddScoped<ISkillService, SkillService>();
 builder.Services.AddScoped<IPaymentService, PaymentService>();
 builder.Services.AddScoped<IRatingService, RatingService>();
+builder.Services.AddScoped<IFcmService, FcmService>();
 
 // Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/JobMatchBackend/Repositories/FcmTokenRepository.cs
+++ b/JobMatchBackend/Repositories/FcmTokenRepository.cs
@@ -1,0 +1,59 @@
+using JobMatchBackend.Data;
+using JobMatchBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace JobMatchBackend.Repositories;
+
+public class FcmTokenRepository : IFcmTokenRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public FcmTokenRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task SaveOrUpdateAsync(Guid userId, string token, string? deviceInfo)
+    {
+        var existing = await _dbContext.FcmTokens
+            .FirstOrDefaultAsync(t => t.Token == token);
+
+        if (existing != null)
+        {
+            existing.IdUser = userId;
+            existing.DeviceInfo = deviceInfo;
+            existing.UpdatedAt = DateTime.UtcNow;
+        }
+        else
+        {
+            _dbContext.FcmTokens.Add(new FcmToken
+            {
+                IdUser = userId,
+                Token = token,
+                DeviceInfo = deviceInfo
+            });
+        }
+
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task<List<string>> GetTokensByUserIdAsync(Guid userId)
+    {
+        return await _dbContext.FcmTokens
+            .Where(t => t.IdUser == userId)
+            .Select(t => t.Token)
+            .ToListAsync();
+    }
+
+    public async Task DeleteByTokenAsync(string token)
+    {
+        var entity = await _dbContext.FcmTokens
+            .FirstOrDefaultAsync(t => t.Token == token);
+
+        if (entity != null)
+        {
+            _dbContext.FcmTokens.Remove(entity);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/JobMatchBackend/Repositories/IFcmTokenRepository.cs
+++ b/JobMatchBackend/Repositories/IFcmTokenRepository.cs
@@ -1,0 +1,8 @@
+namespace JobMatchBackend.Repositories;
+
+public interface IFcmTokenRepository
+{
+    Task SaveOrUpdateAsync(Guid userId, string token, string? deviceInfo);
+    Task<List<string>> GetTokensByUserIdAsync(Guid userId);
+    Task DeleteByTokenAsync(string token);
+}

--- a/JobMatchBackend/Services/ApplicationService.cs
+++ b/JobMatchBackend/Services/ApplicationService.cs
@@ -12,6 +12,7 @@ public class ApplicationService : IApplicationService
     private readonly IUserRepository _userRepository;
     private readonly IJobRepository _jobRepository;
     private readonly IContractRepository _contractRepository;
+    private readonly IFcmService _fcmService;
     private readonly ILogger<ApplicationService> _logger;
 
     public ApplicationService(
@@ -19,12 +20,14 @@ public class ApplicationService : IApplicationService
         IUserRepository userRepository,
         IJobRepository jobRepository,
         IContractRepository contractRepository,
+        IFcmService fcmService,
         ILogger<ApplicationService> logger)
     {
         _applicationRepository = applicationRepository;
         _userRepository = userRepository;
         _jobRepository = jobRepository;
         _contractRepository = contractRepository;
+        _fcmService = fcmService;
         _logger = logger;
     }
 
@@ -180,22 +183,23 @@ public class ApplicationService : IApplicationService
             Status = "pending"
         };
 
-        await _applicationRepository.CreateAsync(application);
+        var created = await _applicationRepository.CreateAsync(application);
 
-        NotifyCompany(job.Company?.Email, job.Title, student.FullName);
+        var title = "Nueva postulación";
+        var body = $"{student.FullName} aplicó a \"{job.Title}\"";
+        _ = _fcmService.SendToUserAsync(job.IdCompany, title, body, new Dictionary<string, string>
+        {
+            ["type"]    = "new_application",
+            ["entityId"] = created.IdApplication.ToString(),
+            ["title"]   = title,
+            ["body"]    = body
+        });
 
         return new CreateApplicationResponse
         {
             Message = "Application submitted successfully",
             Status = application.Status
         };
-    }
-
-    private void NotifyCompany(string? companyEmail, string jobTitle, string? studentName)
-    {
-        _logger.LogInformation(
-            "NOTIFICATION: New application received - Job: '{JobTitle}', Applicant: '{StudentName}', Company email: '{CompanyEmail}'",
-            jobTitle, studentName ?? "Unknown", companyEmail ?? "Unknown");
     }
     
     public async Task<ApplicationDetailResponse> GetApplicationDetailsAsync(int applicationId, Guid userId, string userRole)

--- a/JobMatchBackend/Services/ApplicationService.cs
+++ b/JobMatchBackend/Services/ApplicationService.cs
@@ -187,7 +187,7 @@ public class ApplicationService : IApplicationService
 
         var title = "Nueva postulación";
         var body = $"{student.FullName} aplicó a \"{job.Title}\"";
-        _ = _fcmService.SendToUserAsync(job.IdCompany, title, body, new Dictionary<string, string>
+        await _fcmService.SendToUserAsync(job.IdCompany, title, body, new Dictionary<string, string>
         {
             ["type"]    = "new_application",
             ["entityId"] = created.IdApplication.ToString(),

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -7,10 +7,12 @@ namespace JobMatchBackend.Services;
 public class ContractService : IContractService
 {
     private readonly IContractRepository _contractRepository;
+    private readonly IFcmService _fcmService;
 
-    public ContractService(IContractRepository contractRepository)
+    public ContractService(IContractRepository contractRepository, IFcmService fcmService)
     {
         _contractRepository = contractRepository;
+        _fcmService = fcmService;
     }
 
     public async Task<ContractAcceptResponse> AcceptContractAsync(int contractId, Guid studentId)
@@ -34,6 +36,18 @@ public class ContractService : IContractService
 
         contract.Job.Status = "in-progress";
         await _contractRepository.UpdateAsync(contract);
+
+        var studentName = contract.Student?.FullName ?? "El estudiante";
+        var jobTitle    = contract.Job.Title;
+        var title       = "Contrato aceptado";
+        var body        = $"{studentName} aceptó el contrato para \"{jobTitle}\"";
+        _ = _fcmService.SendToUserAsync(contract.IdCompany, title, body, new Dictionary<string, string>
+        {
+            ["type"]     = "contract_accepted",
+            ["entityId"] = contract.IdContract.ToString(),
+            ["title"]    = title,
+            ["body"]     = body
+        });
 
         return new ContractAcceptResponse
         {

--- a/JobMatchBackend/Services/ContractService.cs
+++ b/JobMatchBackend/Services/ContractService.cs
@@ -41,7 +41,7 @@ public class ContractService : IContractService
         var jobTitle    = contract.Job.Title;
         var title       = "Contrato aceptado";
         var body        = $"{studentName} aceptó el contrato para \"{jobTitle}\"";
-        _ = _fcmService.SendToUserAsync(contract.IdCompany, title, body, new Dictionary<string, string>
+        await _fcmService.SendToUserAsync(contract.IdCompany, title, body, new Dictionary<string, string>
         {
             ["type"]     = "contract_accepted",
             ["entityId"] = contract.IdContract.ToString(),

--- a/JobMatchBackend/Services/FcmService.cs
+++ b/JobMatchBackend/Services/FcmService.cs
@@ -56,7 +56,10 @@ public class FcmService : IFcmService
                 }
             };
 
-            await FirebaseMessaging.DefaultInstance.SendAsync(message);
+            var messageId = await FirebaseMessaging.DefaultInstance.SendAsync(message);
+            _logger.LogInformation(
+                "FCM notification sent successfully. MessageId: {MessageId}, Title: {Title}",
+                messageId, title);
         }
         catch (FirebaseMessagingException ex)
             when (ex.MessagingErrorCode == MessagingErrorCode.Unregistered ||
@@ -68,7 +71,7 @@ public class FcmService : IFcmService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send FCM notification to token.");
+            _logger.LogError(ex, "Failed to send FCM notification. Title: {Title}", title);
         }
     }
 }

--- a/JobMatchBackend/Services/FcmService.cs
+++ b/JobMatchBackend/Services/FcmService.cs
@@ -1,0 +1,74 @@
+using FirebaseAdmin.Messaging;
+using JobMatchBackend.Repositories;
+
+namespace JobMatchBackend.Services;
+
+public class FcmService : IFcmService
+{
+    private readonly IFcmTokenRepository _fcmTokenRepository;
+    private readonly ILogger<FcmService> _logger;
+
+    public FcmService(IFcmTokenRepository fcmTokenRepository, ILogger<FcmService> logger)
+    {
+        _fcmTokenRepository = fcmTokenRepository;
+        _logger = logger;
+    }
+
+    public async Task SendToUserAsync(Guid userId, string title, string body, Dictionary<string, string>? data = null)
+    {
+        var tokens = await _fcmTokenRepository.GetTokensByUserIdAsync(userId);
+        if (tokens.Count == 0) return;
+
+        var tasks = tokens.Select(token => SendToTokenAsync(token, title, body, data));
+        await Task.WhenAll(tasks);
+    }
+
+    public async Task SendToTokenAsync(string token, string title, string body, Dictionary<string, string>? data = null)
+    {
+        try
+        {
+            var message = new Message
+            {
+                Token = token,
+                Notification = new Notification
+                {
+                    Title = title,
+                    Body = body
+                },
+                Data = data ?? new Dictionary<string, string>(),
+                Android = new AndroidConfig
+                {
+                    Priority = Priority.High,
+                    Notification = new AndroidNotification
+                    {
+                        Title = title,
+                        Body = body,
+                        Sound = "default"
+                    }
+                },
+                Apns = new ApnsConfig
+                {
+                    Aps = new Aps
+                    {
+                        Sound = "default",
+                        Badge = 1
+                    }
+                }
+            };
+
+            await FirebaseMessaging.DefaultInstance.SendAsync(message);
+        }
+        catch (FirebaseMessagingException ex)
+            when (ex.MessagingErrorCode == MessagingErrorCode.Unregistered ||
+                  ex.MessagingErrorCode == MessagingErrorCode.InvalidArgument)
+        {
+            // Token is no longer valid — remove it silently
+            _logger.LogInformation("Removing invalid FCM token: {Token}", token[..Math.Min(20, token.Length)]);
+            await _fcmTokenRepository.DeleteByTokenAsync(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send FCM notification to token.");
+        }
+    }
+}

--- a/JobMatchBackend/Services/IFcmService.cs
+++ b/JobMatchBackend/Services/IFcmService.cs
@@ -1,0 +1,7 @@
+namespace JobMatchBackend.Services;
+
+public interface IFcmService
+{
+    Task SendToUserAsync(Guid userId, string title, string body, Dictionary<string, string>? data = null);
+    Task SendToTokenAsync(string token, string title, string body, Dictionary<string, string>? data = null);
+}

--- a/JobMatchBackend/Services/PaymentService.cs
+++ b/JobMatchBackend/Services/PaymentService.cs
@@ -9,11 +9,13 @@ public class PaymentService : IPaymentService
 {
     private static readonly string[] ValidPaymentMethods = { "transfer", "cash", "sinpe" };
 
-    public  readonly IPaymentRepository _paymentRepository;
+    private readonly IPaymentRepository _paymentRepository;
+    private readonly IFcmService _fcmService;
 
-    public PaymentService(IPaymentRepository paymentRepository)
+    public PaymentService(IPaymentRepository paymentRepository, IFcmService fcmService)
     {
         _paymentRepository = paymentRepository;
+        _fcmService = fcmService;
     }
 
     public async Task<List<PaymentResponse>> GetPaymentHistoryAsync(Guid userId, DateOnly? startDate, DateOnly? endDate)
@@ -55,6 +57,17 @@ public class PaymentService : IPaymentService
 
         var createdPayment = await _paymentRepository.CreatePaymentAsync(payment);
         createdPayment.Contract = contract;
+
+        var jobTitle = contract.Job?.Title ?? "tu trabajo";
+        var title    = "Pago recibido";
+        var body     = $"Se registró un pago de ₡{(long)request.Amount:N0} para \"{jobTitle}\"";
+        _ = _fcmService.SendToUserAsync(contract.IdStudent, title, body, new Dictionary<string, string>
+        {
+            ["type"]     = "payment_registered",
+            ["entityId"] = createdPayment.IdPayment.ToString(),
+            ["title"]    = title,
+            ["body"]     = body
+        });
 
         return ToResponse(createdPayment, callerId);
     }

--- a/JobMatchBackend/Services/PaymentService.cs
+++ b/JobMatchBackend/Services/PaymentService.cs
@@ -61,7 +61,7 @@ public class PaymentService : IPaymentService
         var jobTitle = contract.Job?.Title ?? "tu trabajo";
         var title    = "Pago recibido";
         var body     = $"Se registró un pago de ₡{(long)request.Amount:N0} para \"{jobTitle}\"";
-        _ = _fcmService.SendToUserAsync(contract.IdStudent, title, body, new Dictionary<string, string>
+        await _fcmService.SendToUserAsync(contract.IdStudent, title, body, new Dictionary<string, string>
         {
             ["type"]     = "payment_registered",
             ["entityId"] = createdPayment.IdPayment.ToString(),

--- a/JobMatchBackend/appsettings.Development.json
+++ b/JobMatchBackend/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Firebase": {
+    "CredentialPath": "firebase-adminsdk.json"
   }
 }


### PR DESCRIPTION
 # Pull Request

  ## Description

  Implements Firebase Cloud Messaging (FCM) push notification support in the .NET backend. The backend can now
  store device tokens per user and send push notifications when key business events occur: new applicant on a job,
  contract accepted by a student, and payment registered by a company.

  ---

  ## Related Issue

  Closes #84 

  ---

  ## Changes Included

  ### Backend Changes

  * [x] Added new endpoint(s) — `POST /notifications/token`, `DELETE /notifications/token/{token}`
  * [x] Added/updated DTOs — `RegisterFcmTokenRequest`
  * [x] Added/updated services — `IFcmService` / `FcmService`; injected into `ApplicationService`,
  `ContractService`, `PaymentService`
  * [x] Added/updated repositories — `IFcmTokenRepository` / `FcmTokenRepository`
  * [ ] Added/updated database migrations
  * [ ] Added validations
  * [x] Added exception handling — invalid/expired tokens are automatically removed when FCM reports them
  * [x] Other: Firebase Admin SDK configured in `Program.cs`; `FirebaseAdmin` NuGet package added

  ### Frontend / Mobile Changes

  * [ ] Added new screen(s)
  * [ ] Added ViewModel(s)
  * [ ] Added navigation
  * [ ] Added API integration
  * [ ] Added loading/error states
  * [ ] Added validation
  * [ ] Updated UI components
  * [ ] Other:

  ---

  ## Architecture

  FcmTokensController → IFcmTokenRepository → AppDbContext (fcm_tokens table)

  Business event triggers (fire-and-forget):
  ApplicationService  ──┐
  ContractService     ──┼──► IFcmService → Firebase Admin SDK → FCM → Device
  PaymentService      ──┘

  FCM token management follows the same layered architecture as the rest of the project: controller handles HTTP
  and auth, repository handles data access, service handles business logic and FCM communication. Notification
  triggers are fire-and-forget (`_ = _fcmService.SendToUserAsync(...)`) so they do not block or slow down the
  endpoint response.

  ---

  ## API / Database Changes

  ### New Endpoints

  | Method | Path | Auth | Description |
  |---|---|---|---|
  | `POST` | `/notifications/token` | Bearer | Register or update a device FCM token |
  | `DELETE` | `/notifications/token/{token}` | Bearer | Remove a device FCM token |

  ### `POST /notifications/token` Request Body

  ```json
  {
    "token": "fcm-device-token-string",
    "deviceInfo": "Android 14"
  }
  ```
  Notification Payload (sent to devices)

  ```json
  {
    "type": "new_application | contract_accepted | payment_registered",
    "entityId": "123",
    "title": "Título en español",
    "body": "Mensaje en español"
  }
```

  Database

  Uses the existing fcm_tokens table (already in initial migration). No new migration required.

  ---
  Testing Performed

  - [x] Feature tested manually
  - [ ] Navigation tested
  - [x] Error handling tested
  - [x] Validation tested
  - [x] Backend integration tested
  - [x] No crashes detected

  Test Details

  - POST /notifications/token with valid Bearer token stores the token correctly.
  - Duplicate token upserts correctly (same token, different device info updates the record).
  - DELETE /notifications/token/{token} removes the token.
  - New applicant event triggers FCM send to the company's registered tokens.
  - Contract accepted event triggers FCM send to the company.
  - Payment registered event triggers FCM send to the student.
  - Invalid/expired tokens returned by FCM are removed from the database automatically.
  - dotnet build completed successfully with no new errors.

  ---
  Notes

  Firebase credentials are stored in firebase-adminsdk.json at the project root (already in .gitignore). The
  appsettings.json must include:

```json
  "Firebase": {
    "CredentialPath": "firebase-adminsdk.json"
  }
```

  If the credentials file is missing at startup, the app initializes normally without FCM (graceful degradation).
  Notification sends are fire-and-forget — failures are logged but do not affect the business operation response.
