### PR TITLE
feat: add GET /ratings/me endpoint to retrieve received ratings

### DIFF
--- a/JobMatchBackend/Controllers/RatingsController.cs
+++ b/JobMatchBackend/Controllers/RatingsController.cs
@@ -62,6 +62,33 @@ public class RatingsController : ControllerBase
         }
     }
 
+    [HttpGet("me")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetMyRatings()
+    {
+        Guid callerId;
+        try
+        {
+            callerId = GetCurrentUserId();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+
+        try
+        {
+            var ratings = await _ratingService.GetMyRatingsAsync(callerId);
+            return Ok(ratings);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     private Guid GetCurrentUserId()
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/JobMatchBackend/DTOs/Response/ReceivedRatingResponse.cs
+++ b/JobMatchBackend/DTOs/Response/ReceivedRatingResponse.cs
@@ -1,0 +1,12 @@
+namespace JobMatchBackend.DTOs.Response;
+
+public class ReceivedRatingResponse
+{
+    public int IdRating { get; set; }
+    public int IdContract { get; set; }
+    public string RaterName { get; set; } = string.Empty;
+    public string JobTitle { get; set; } = string.Empty;
+    public int Stars { get; set; }
+    public string? Comment { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/JobMatchBackend/Repositories/IRatingRepository.cs
+++ b/JobMatchBackend/Repositories/IRatingRepository.cs
@@ -8,4 +8,5 @@ public interface IRatingRepository
     Task<bool> HasRatedAsync(int contractId, Guid raterId);
     Task<Rating> AddAsync(Rating rating);
     Task<float> GetAverageRatingAsync(Guid userId);
+    Task<List<Rating>> GetReceivedRatingsAsync(Guid userId);
 }

--- a/JobMatchBackend/Repositories/RatingRepository.cs
+++ b/JobMatchBackend/Repositories/RatingRepository.cs
@@ -42,4 +42,15 @@ public class RatingRepository : IRatingRepository
 
         return (float)ratings.Average(r => r.Stars);
     }
+
+    public async Task<List<Rating>> GetReceivedRatingsAsync(Guid userId)
+    {
+        return await _dbContext.Ratings
+            .Include(r => r.Rater)
+            .Include(r => r.Contract)
+                .ThenInclude(c => c!.Job)
+            .Where(r => r.IdRated == userId)
+            .OrderByDescending(r => r.CreatedAt)
+            .ToListAsync();
+    }
 }

--- a/JobMatchBackend/Services/IRatingService.cs
+++ b/JobMatchBackend/Services/IRatingService.cs
@@ -6,4 +6,5 @@ namespace JobMatchBackend.Services;
 public interface IRatingService
 {
     Task<RatingResponse> CreateRatingAsync(CreateRatingRequest request, Guid callerId);
+    Task<List<ReceivedRatingResponse>> GetMyRatingsAsync(Guid callerId);
 }

--- a/JobMatchBackend/Services/RatingService.cs
+++ b/JobMatchBackend/Services/RatingService.cs
@@ -59,4 +59,20 @@ public class RatingService : IRatingService
             CreatedAt = created.CreatedAt
         };
     }
+
+    public async Task<List<ReceivedRatingResponse>> GetMyRatingsAsync(Guid callerId)
+    {
+        var ratings = await _ratingRepository.GetReceivedRatingsAsync(callerId);
+
+        return ratings.Select(r => new ReceivedRatingResponse
+        {
+            IdRating = r.IdRating,
+            IdContract = r.IdContract,
+            RaterName = r.Rater?.CompanyName ?? r.Rater?.FullName ?? "Anónimo",
+            JobTitle = r.Contract?.Job?.Title ?? string.Empty,
+            Stars = r.Stars,
+            Comment = r.Comment,
+            CreatedAt = r.CreatedAt
+        }).ToList();
+    }
 }


### PR DESCRIPTION
# Pull Request

## Description

Adds a `GET /ratings/me` endpoint that returns all ratings received by the authenticated user. Both students and companies can use this endpoint to see the feedback others have left for them, including the rater's name, job title, star rating, comment, and date.

---

## Changes Included

### Backend Changes

* [x] Added new endpoint(s)
* [x] Added/updated DTOs
* [x] Added/updated services
* [x] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [x] Added exception handling
* [ ] Other:

---

## Architecture

Controller → Service → Repository → AppDbContext (SQL Server)

`RatingsController` receives the authenticated request, extracts the caller's ID from the JWT claim, delegates to `RatingService.GetMyRatingsAsync()`, which calls `RatingRepository.GetReceivedRatingsAsync()`. The repository queries `Ratings` filtered by `IdRated == callerId`, with `.Include` on `Rater` and `Contract → Job` to resolve names and job title in a single query.

---

## Testing Performed

* [x] Feature tested manually
* [ ] Navigation tested
* [x] Error handling tested
* [ ] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Tested via Swagger with a valid JWT token for both a student and a company account that had existing ratings in the database. Verified:

Returns 200 OK with the correct list ordered by most recent first.

---

## Evidence

<img width="1600" height="737" alt="image" src="https://github.com/user-attachments/assets/94ff5d14-f1e0-4aad-ab3b-3eba078958ae" />

