### PR TITLE
Feature/implement description update issue #86

### DIFF
--- a/JobMatchBackend/Controllers/UsersController.cs
+++ b/JobMatchBackend/Controllers/UsersController.cs
@@ -52,6 +52,35 @@ public class UsersController : ControllerBase
         }
     }
 
+    [HttpPut("{userId}/description")]
+    public async Task<IActionResult> UpdateDescription(Guid userId, [FromBody] UpdateDescriptionRequest request)
+    {
+        try
+        {
+            var authenticatedUserId = GetCurrentUserId();
+            if (authenticatedUserId != userId)
+                return StatusCode(403, new { message = "You can only update your own description" });
+
+            if (string.IsNullOrWhiteSpace(request.Description))
+                return BadRequest(new { message = "Description cannot be empty" });
+
+            var result = await _userService.UpdateDescriptionAsync(userId, request.Description);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new { message = "User not found" });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized(new { message = "Invalid authenticated user" });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { message = "Internal server error" });
+        }
+    }
+
     [HttpDelete("{userId}")]
     public async Task<IActionResult> DeleteUser(Guid userId, [FromBody] DeleteUserRequest request)
     {

--- a/JobMatchBackend/DTOs/Request/UpdateDescriptionRequest.cs
+++ b/JobMatchBackend/DTOs/Request/UpdateDescriptionRequest.cs
@@ -5,5 +5,6 @@ namespace JobMatchBackend.DTOs.Request;
 public class UpdateDescriptionRequest
 {
     [Required]
+    [MaxLength(500)]
     public string Description { get; set; } = string.Empty;
 }

--- a/JobMatchBackend/DTOs/Request/UpdateDescriptionRequest.cs
+++ b/JobMatchBackend/DTOs/Request/UpdateDescriptionRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JobMatchBackend.DTOs.Request;
+
+public class UpdateDescriptionRequest
+{
+    [Required]
+    public string Description { get; set; } = string.Empty;
+}

--- a/JobMatchBackend/DTOs/Response/Student/UserProfileResponse.cs
+++ b/JobMatchBackend/DTOs/Response/Student/UserProfileResponse.cs
@@ -8,6 +8,6 @@ public class UserProfileResponse
     public string? Role { get; set; }
     public string? Avatar { get; set; }
     public string? Phone { get; set; }
-    public string? Bio { get; set; }
+    public string? Description { get; set; }
     public bool Active { get; set; }
 }

--- a/JobMatchBackend/Mappers/StudentMapper.cs
+++ b/JobMatchBackend/Mappers/StudentMapper.cs
@@ -19,7 +19,7 @@ public static class StudentMapper
                 Role = user.Role,
                 Avatar = user.AvatarUrl,
                 Phone = user.Phone,
-                Bio = user.Bio,
+                Description = user.Description,
                 Active = user.IsActive
             },
             University = user.University,

--- a/JobMatchBackend/Services/IUserService.cs
+++ b/JobMatchBackend/Services/IUserService.cs
@@ -11,4 +11,5 @@ public interface IUserService
     Task<RegisterCompanyResponse> CreateCompanyAsync(RegisterCompany request);
     Task<string> SoftDeleteUserAsync(Guid userId, Guid authenticatedUserId, DeleteUserRequest request);
     Task<UserProfileResponse> UpdateAvatarAsync(Guid userId, IFormFile avatar);
+    Task<UserProfileResponse> UpdateDescriptionAsync(Guid userId, string description);
 }

--- a/JobMatchBackend/Services/UserService.cs
+++ b/JobMatchBackend/Services/UserService.cs
@@ -169,7 +169,33 @@ public class UserService : IUserService
             Role = user.Role,
             Avatar = user.AvatarUrl,
             Phone = user.Phone,
-            Bio = user.Bio,
+            Description = user.Description,
+            Active = user.IsActive
+        };
+    }
+
+    public async Task<UserProfileResponse> UpdateDescriptionAsync(Guid userId, string description)
+    {
+        var user = await _userRepository.GetByIdAsync(userId);
+        if (user == null)
+            throw new KeyNotFoundException("User not found");
+
+        if (!user.IsActive)
+            throw new KeyNotFoundException("User not found");
+
+        user.Description = description;
+        user.UpdatedAt = DateTime.UtcNow;
+        await _userRepository.UpdateAsync(user);
+
+        return new UserProfileResponse
+        {
+            Id = user.Id,
+            FullName = user.FullName,
+            Email = user.Email,
+            Role = user.Role,
+            Avatar = user.AvatarUrl,
+            Phone = user.Phone,
+            Description = user.Description,
             Active = user.IsActive
         };
     }

--- a/JobMatchBackend/docs/Api contracts.yaml
+++ b/JobMatchBackend/docs/Api contracts.yaml
@@ -214,6 +214,41 @@ paths:
           description: User not found
         "500":
           description: Internal server error
+  /users/{userId}/description:
+    put:
+      tags:
+        - Users
+      summary: Update user description
+      description: Updates the description field for the authenticated user.
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateDescriptionRequest"
+      responses:
+        "200":
+          description: Description updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserProfileResponse"
+        "400":
+          description: Description is empty or missing
+        "401":
+          description: Missing or invalid JWT token
+        "403":
+          description: Authenticated user does not match the requested user ID
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
   /students/{studentId}:
     get:
       tags:
@@ -805,6 +840,13 @@ paths:
           description: Internal server error
 components:
   schemas:
+    UpdateDescriptionRequest:
+      required:
+        - description
+      type: object
+      properties:
+        description:
+          type: string
     RegisterStudentRequest:
       required:
         - career


### PR DESCRIPTION
## Description
Implements the `PUT /users/{userId}/description` endpoint to allow any authenticated user (student or company) to update their profile description. The `Description` column already existed on the `users` table — no migration was needed.

---

## Related Issue
Closes #86

---

## Changes Included

### Backend Changes
* [x] Added new endpoint(s) — `PUT /users/{userId}/description`
* [x] Added/updated DTOs — Created `UpdateDescriptionRequest` with `[Required]` validation. Updated `UserProfileResponse` to expose `Description` instead of `Bio`
* [x] Added/updated services — Added `UpdateDescriptionAsync` to `IUserService` and `UserService`
* [x] Added validations — Returns 400 if description is null or whitespace. Rejects inactive users with 404
* [x] Added exception handling — 400 (empty description), 401 (invalid auth claim), 403 (wrong user), 404 (not found), 500 (unexpected error)
* [x] Other: Updated `StudentMapper.cs` to map `user.Description` instead of `user.Bio` into `UserProfileResponse`. Updated API contract YAML with new endpoint and `UpdateDescriptionRequest` schema

### Frontend / Mobile Changes
* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added loading/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture
UI → ViewModel → Repository → API → Database

The endpoint follows the existing layered architecture:
`UsersController` → `IUserService` → `UserService` → `IUserRepository` → `AppDbContext`

---

## API / Database Changes

**New endpoint:** `PUT /users/{userId}/description`
- Request: `application/json` with `{ "description": "string" }` (required, non-empty)
- Response 200: `UserProfileResponse` with updated fields
- Response 400: Description is empty or missing
- Response 401: Missing or invalid JWT token
- Response 403: Authenticated user does not match the requested `userId`
- Response 404: User not found or inactive
- Response 500: Internal server error

**Database:** No new migrations. Uses existing `Description` column (`string?`) on the `users` table.

**DTO change:** `UserProfileResponse.Bio` replaced with `UserProfileResponse.Description` to correctly surface the user's description field instead of the unused `Bio` field.

API contract YAML updated with the new endpoint and schema.

---

## Testing Performed
* [x] Feature tested manually
* [x] Backend integration tested
* [x] No crashes detected
* [ ] Navigation tested
* [ ] Error handling tested
* [ ] Validation tested

### Test Details
Verified that `PUT /users/{userId}/description` updates the `Description` column in the database and returns the updated `UserProfileResponse`. Confirmed the field is correctly mapped through `StudentMapper` and returned in `GET /students/{studentId}`.

---

## Evidence
<!-- Drag and drop files here -->

---

## Notes
- `Bio` was an unused field on `UserProfileResponse`. It has been replaced by `Description` which maps to `User.Description` — the field used by both students and companies for profile descriptions.
- The frontend must update any references from `user.bio` to `user.description` to consume this change correctly.